### PR TITLE
Extend setup with VS 2026, Aspire, Copilot tooling, and Azure MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ This repository contains setup scripts for configuring booth machines. The scrip
 
 - Installs and configures Visual Studio Code and Visual Studio Code Insiders.
 - Installs GitHub CLI and a suite of GitHub CLI extensions.
+- Installs the GitHub Copilot CLI (`copilot`).
+- Installs the GitHub Copilot desktop app (via the [`github-copilot-app`](https://formulae.brew.sh/cask/github-copilot-app) Homebrew cask on macOS; direct download from the [`github/app`](https://github.com/github/app) releases on Windows).
+- Installs the [Microsoft Aspire](https://aspire.dev) CLI and registers its MCP server with Copilot CLI.
+- Installs Visual Studio Enterprise with Web + Azure + .NET desktop workloads (Windows only).
+- Registers MCP servers (Playwright, Microsoft Learn, Astro docs, Svelte docs, Aspire, Azure, Azure DevOps) in `~/.copilot/mcp-config.json`. Node-based MCP servers (Playwright, Azure, Azure DevOps) are installed globally via `npm install -g` so they launch from their installed binaries rather than fetching via `npx` at runtime.
 - Configures VLC media player settings.
 - Sets up Progressive Web Apps (PWAs) for GitHub tools.
 - Creates a demo loader script to launch all required applications and sites.
@@ -42,3 +47,30 @@ The configuration for the setup scripts is stored in the `config.json` file. You
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+
+## Post-setup configuration
+
+Some integrations require values that the setup script can't guess for you:
+
+### Azure DevOps MCP server
+
+The Azure DevOps MCP server entry in `config.json` is registered with a literal placeholder organization (`<YOUR-ADO-ORG>`). The setup scripts detect this placeholder and **skip registering the server** until you supply a real value, so your `~/.copilot/mcp-config.json` won't contain a broken entry.
+
+To enable it:
+
+1. Edit `config.json` and replace `<YOUR-ADO-ORG>` in the `azure-devops` entry under `shared.mcp_servers` with your Azure DevOps organization slug (e.g. `contoso` for `https://dev.azure.com/contoso`).
+2. Re-run the setup script. The MCP server will be added to `~/.copilot/mcp-config.json`.
+
+Alternatively, edit `~/.copilot/mcp-config.json` directly.
+
+### Visual Studio (Windows)
+
+Visual Studio is installed via the official Microsoft bootstrapper (`vs_enterprise.exe`) — not via winget — because winget only publishes manifests for VS 2017/2019/2022. The script downloads the latest Visual Studio 2026 Enterprise bootstrapper from `https://aka.ms/vs/stable/vs_enterprise.exe` (per the [official command-line install docs](https://learn.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio)) and runs it with the configured workloads.
+
+To switch channels or editions, edit `config.windows.visual_studio` in `config.json`:
+
+- **Insiders preview** instead of stable: change `bootstrapper_url` to `https://aka.ms/vs/insiders/vs_enterprise.exe`
+- **Different edition**: swap to `vs_professional.exe` or `vs_community.exe` and update `edition` accordingly
+- **Add/remove workloads**: edit the `workloads` array using [official workload IDs](https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-enterprise)
+
+`install_path` is used for the idempotency check; update it if you change edition (e.g. `…\\2026\\Professional`).

--- a/README.md
+++ b/README.md
@@ -54,14 +54,22 @@ Some integrations require values that the setup script can't guess for you:
 
 ### Azure DevOps MCP server
 
-The Azure DevOps MCP server entry in `config.json` is registered with a literal placeholder organization (`<YOUR-ADO-ORG>`). The setup scripts detect this placeholder and **skip registering the server** until you supply a real value, so your `~/.copilot/mcp-config.json` won't contain a broken entry.
+The Azure DevOps MCP server needs your organization slug (e.g. `contoso` for `https://dev.azure.com/contoso`). Setup will prompt you for it once and cache the answer.
 
-To enable it:
+**During setup:**
 
-1. Edit `config.json` and replace `<YOUR-ADO-ORG>` in the `azure-devops` entry under `shared.mcp_servers` with your Azure DevOps organization slug (e.g. `contoso` for `https://dev.azure.com/contoso`).
-2. Re-run the setup script. The MCP server will be added to `~/.copilot/mcp-config.json`.
+```
+Azure DevOps organization name (leave blank to skip the Azure DevOps MCP server)
+> contoso
+```
 
-Alternatively, edit `~/.copilot/mcp-config.json` directly.
+- Enter your org slug to register the server.
+- Leave it blank to skip the server entirely (the rest of setup continues).
+- On re-runs, the prompt shows your cached value; press Enter to keep it, type a new value to change it, or `-` to clear it.
+
+**Non-interactive runs** (CI, piped input, etc.) skip the prompt and either use the cached value or skip the server. To set the org without a prompt, export `ADO_ORG=contoso` (or `ADO_ORG=` to explicitly skip) before running setup.
+
+**State file:** the cached value lives at `${COPILOT_HOME:-~/.copilot}/machine-setup-state.json` (Mac/Linux) or `%COPILOT_HOME%\machine-setup-state.json` / `%USERPROFILE%\.copilot\machine-setup-state.json` (Windows). Edit or delete this file to change the cached answer outside setup.
 
 ### Visual Studio (Windows)
 

--- a/config.json
+++ b/config.json
@@ -29,10 +29,8 @@
       {
         "name": "playwright",
         "type": "local",
-        "command": "npx",
-        "args": [
-          "@playwright/mcp@latest"
-        ]
+        "command": "playwright-mcp",
+        "args": []
       },
       {
         "name": "microsoft-learn",
@@ -48,7 +46,41 @@
         "name": "svelte-docs",
         "type": "http",
         "url": "https://mcp.svelte.dev/mcp"
+      },
+      {
+        "name": "aspire",
+        "type": "local",
+        "command": "aspire",
+        "args": [
+          "agent",
+          "mcp"
+        ]
+      },
+      {
+        "name": "azure-devops",
+        "type": "local",
+        "command": "mcp-server-azuredevops",
+        "args": [
+          "<YOUR-ADO-ORG>"
+        ]
+      },
+      {
+        "name": "azure",
+        "type": "local",
+        "command": "azmcp",
+        "args": [
+          "server",
+          "start"
+        ]
       }
+    ],
+    "npm_global_packages": [
+      "@playwright/mcp",
+      "@azure/mcp",
+      "@azure-devops/mcp"
+    ],
+    "placeholders": [
+      "<YOUR-ADO-ORG>"
     ],
     "repos_to_clone": [
       "octobooth/setup-scripts",
@@ -64,7 +96,8 @@
         "vlc",
         "copilot-cli",
         "google-chrome",
-        "github"
+        "github",
+        "github-copilot-app"
       ],
       "formulas": [
         "gh",
@@ -97,8 +130,24 @@
       "VideoLAN.VLC",
       "GitHub.Copilot",
       "Google.Chrome",
-      "GitHub.GitHubDesktop"
+      "GitHub.GitHubDesktop",
+      "OpenJS.NodeJS.LTS"
     ],
+    "visual_studio": {
+      "edition": "Enterprise",
+      "bootstrapper_url": "https://aka.ms/vs/stable/vs_enterprise.exe",
+      "install_path": "C:\\Program Files\\Microsoft Visual Studio\\2026\\Enterprise",
+      "workloads": [
+        "Microsoft.VisualStudio.Workload.NetWeb",
+        "Microsoft.VisualStudio.Workload.Azure",
+        "Microsoft.VisualStudio.Workload.ManagedDesktop"
+      ],
+      "include_recommended": true
+    },
+    "copilot_app": {
+      "url_x64": "https://github.com/github/app/releases/latest/download/GitHub-Copilot-windows-x64-setup.exe",
+      "url_arm64": "https://github.com/github/app/releases/latest/download/GitHub-Copilot-windows-arm64-setup.exe"
+    },
     "editors": [
       {
         "name": "VS Code",

--- a/setup.ps1
+++ b/setup.ps1
@@ -107,6 +107,160 @@ function Import-Config {
 }
 
 # ----------------------------------------
+# Setup state (per-machine inputs)
+# ----------------------------------------
+
+function Get-SetupStatePath {
+    $copilotHome = if ($env:COPILOT_HOME) { $env:COPILOT_HOME } else { Join-Path $env:USERPROFILE ".copilot" }
+    return (Join-Path $copilotHome "machine-setup-state.json")
+}
+
+# Reads the setup state into $script:AdoOrgValue and $script:AdoOrgMode.
+# Tolerates missing or corrupt state.
+function Get-SetupState {
+    $script:AdoOrgValue = ""
+    $script:AdoOrgMode = ""
+
+    $statePath = Get-SetupStatePath
+    if (-not (Test-Path $statePath)) { return }
+
+    try {
+        $state = Get-Content -Raw -Path $statePath -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        Write-Warn "Setup state file at $statePath is not valid JSON; ignoring"
+        return
+    }
+
+    if ($state.PSObject.Properties.Name -contains 'inputs' -and
+        $state.inputs.PSObject.Properties.Name -contains 'azure_devops_org') {
+        $entry = $state.inputs.azure_devops_org
+        if ($entry.PSObject.Properties.Name -contains 'value') { $script:AdoOrgValue = [string]$entry.value }
+        if ($entry.PSObject.Properties.Name -contains 'mode')  { $script:AdoOrgMode  = [string]$entry.mode  }
+    }
+}
+
+# Atomically writes the current $script:AdoOrg* values to the state file.
+function Save-SetupState {
+    $statePath = Get-SetupStatePath
+    $copilotHome = Split-Path -Parent $statePath
+    if (-not (Test-Path $copilotHome)) {
+        New-Item -Path $copilotHome -ItemType Directory -Force | Out-Null
+    }
+
+    $existing = [PSCustomObject]@{ inputs = [PSCustomObject]@{} }
+    if (Test-Path $statePath) {
+        try {
+            $existing = Get-Content -Raw -Path $statePath -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+            if ($null -eq $existing.inputs) {
+                $existing | Add-Member -NotePropertyName inputs -NotePropertyValue ([PSCustomObject]@{}) -Force
+            }
+        } catch {
+            $existing = [PSCustomObject]@{ inputs = [PSCustomObject]@{} }
+        }
+    }
+
+    $entry = [PSCustomObject]@{ value = $script:AdoOrgValue; mode = $script:AdoOrgMode }
+    $existing.inputs | Add-Member -NotePropertyName azure_devops_org -NotePropertyValue $entry -Force
+
+    $tmp = "$statePath.tmp"
+    try {
+        $existing | ConvertTo-Json -Depth 10 | Out-File -FilePath $tmp -Encoding UTF8 -Force
+        # Validate before move
+        $null = Get-Content -Raw -Path $tmp | ConvertFrom-Json
+        Move-Item -Path $tmp -Destination $statePath -Force
+    } catch {
+        Write-Warn "Failed to persist setup state: $_"
+        if (Test-Path $tmp) { Remove-Item $tmp -ErrorAction SilentlyContinue }
+    }
+}
+
+# Prompts (when TTY) for per-machine inputs.
+# Precedence: ADO_ORG env var > interactive prompt > cached value > skip.
+function Read-SetupInputs {
+    Get-SetupState
+
+    # 1. Env var override (explicit empty = skip)
+    if (Test-Path env:ADO_ORG) {
+        $envVal = [string]$env:ADO_ORG
+        $trimmed = $envVal.Trim()
+        if ([string]::IsNullOrEmpty($trimmed)) {
+            $script:AdoOrgValue = ""
+            $script:AdoOrgMode = "skip"
+            Write-Info "ADO_ORG is empty in env; Azure DevOps MCP server will be skipped"
+        } else {
+            $script:AdoOrgValue = $trimmed
+            $script:AdoOrgMode = "configured"
+            Write-Info "Using Azure DevOps org from ADO_ORG env var: $($script:AdoOrgValue)"
+        }
+        Save-SetupState
+        return
+    }
+
+    # 2. Interactive prompt (only when stdin isn't redirected)
+    $interactive = $true
+    try {
+        if ([Console]::IsInputRedirected) { $interactive = $false }
+    } catch {
+        # Some hosts don't expose this; fall through to try Read-Host
+    }
+
+    if ($interactive) {
+        if ($script:AdoOrgMode -eq 'configured' -and -not [string]::IsNullOrEmpty($script:AdoOrgValue)) {
+            $hint = "[current: $($script:AdoOrgValue); Enter to keep, '-' to clear]"
+        } else {
+            $hint = "(leave blank to skip the Azure DevOps MCP server)"
+        }
+
+        $answer = $null
+        try {
+            $answer = Read-Host "Azure DevOps organization name $hint"
+        } catch {
+            Write-Warn "Could not prompt for input; treating Azure DevOps MCP server as skipped"
+            $script:AdoOrgValue = ""
+            $script:AdoOrgMode = "skip"
+            Save-SetupState
+            return
+        }
+
+        $trimmed = if ($null -eq $answer) { "" } else { $answer.Trim() }
+
+        if ([string]::IsNullOrEmpty($trimmed)) {
+            if ($script:AdoOrgMode -eq 'configured' -and -not [string]::IsNullOrEmpty($script:AdoOrgValue)) {
+                Write-Info "Keeping cached Azure DevOps org: $($script:AdoOrgValue)"
+            } else {
+                $script:AdoOrgValue = ""
+                $script:AdoOrgMode = "skip"
+                Write-Info "Azure DevOps MCP server will be skipped"
+            }
+        } elseif ($trimmed -eq '-') {
+            $script:AdoOrgValue = ""
+            $script:AdoOrgMode = "skip"
+            Write-Info "Cleared Azure DevOps org; the MCP server will be skipped"
+        } else {
+            if ($trimmed -match '[\s/:]') {
+                Write-Warn "Azure DevOps org '$trimmed' contains unusual characters; accepting anyway"
+            }
+            $script:AdoOrgValue = $trimmed
+            $script:AdoOrgMode = "configured"
+            Write-Success "Azure DevOps org set to: $($script:AdoOrgValue)"
+        }
+        Save-SetupState
+        return
+    }
+
+    # 3. Non-interactive: fall back to cached value if present
+    if ($script:AdoOrgMode -eq 'configured' -and -not [string]::IsNullOrEmpty($script:AdoOrgValue)) {
+        Write-Info "Non-interactive run; using cached Azure DevOps org: $($script:AdoOrgValue)"
+    } elseif ($script:AdoOrgMode -eq 'skip') {
+        Write-Info "Non-interactive run; cached state says skip Azure DevOps MCP server"
+    } else {
+        Write-Info "Non-interactive run with no cached value; Azure DevOps MCP server will be skipped"
+        $script:AdoOrgValue = ""
+        $script:AdoOrgMode = "skip"
+    }
+}
+
+# ----------------------------------------
 # Function Definitions
 # ----------------------------------------
 
@@ -365,13 +519,32 @@ function Register-MCPServers {
     }
 
     foreach ($server in $config.shared.mcp_servers) {
-        $serverValues = @()
+        # Explicit skip: azure-devops requires a configured org
+        if ($server.name -eq 'azure-devops' -and ($script:AdoOrgMode -ne 'configured' -or [string]::IsNullOrEmpty($script:AdoOrgValue))) {
+            Write-Warn "Skipping MCP server 'azure-devops' (no Azure DevOps org configured — re-run setup to provide one or set ADO_ORG)"
+            continue
+        }
+
+        # Build substituted args/url for this server
+        $substArgs = @()
         if ($server.PSObject.Properties.Name -contains 'args' -and $server.args) {
-            $serverValues += @($server.args)
+            foreach ($a in $server.args) {
+                if ($a -eq '<YOUR-ADO-ORG>' -and -not [string]::IsNullOrEmpty($script:AdoOrgValue)) {
+                    $substArgs += $script:AdoOrgValue
+                } else {
+                    $substArgs += $a
+                }
+            }
         }
+        $substUrl = $null
         if ($server.PSObject.Properties.Name -contains 'url' -and $server.url) {
-            $serverValues += $server.url
+            $substUrl = $server.url
         }
+
+        # Defensive backstop: refuse to register if any placeholder slipped through
+        $serverValues = @()
+        $serverValues += $substArgs
+        if ($null -ne $substUrl) { $serverValues += $substUrl }
 
         $hasPlaceholder = $false
         foreach ($value in $serverValues) {
@@ -382,7 +555,7 @@ function Register-MCPServers {
         }
 
         if ($hasPlaceholder) {
-            Write-Warn "Skipping MCP server '$($server.name)' (contains placeholder value — edit config.json and re-run)"
+            Write-Warn "Skipping MCP server '$($server.name)' (placeholder still present after substitution)"
             continue
         }
 
@@ -391,13 +564,13 @@ function Register-MCPServers {
                 tools   = @("*")
                 type    = $server.type
                 command = $server.command
-                args    = @($server.args)
+                args    = @($substArgs)
             }
         } else {
             [PSCustomObject]@{
                 tools   = @("*")
                 type    = $server.type
-                url     = $server.url
+                url     = $substUrl
                 headers = [PSCustomObject]@{}
             }
         }
@@ -638,6 +811,9 @@ Write-Host "========================================" -ForegroundColor Cyan
 # Bootstrap
 if (-not (Test-Prerequisites)) { return }
 Import-Config
+
+# Prompt for per-machine inputs early
+Read-SetupInputs
 
 # Install packages
 Install-Packages

--- a/setup.ps1
+++ b/setup.ps1
@@ -359,7 +359,33 @@ function Register-MCPServers {
         $mcpConfig = [PSCustomObject]@{ mcpServers = [PSCustomObject]@{} }
     }
 
+    $placeholders = @()
+    if ($config.shared.PSObject.Properties.Name -contains 'placeholders') {
+        $placeholders = @($config.shared.placeholders)
+    }
+
     foreach ($server in $config.shared.mcp_servers) {
+        $serverValues = @()
+        if ($server.PSObject.Properties.Name -contains 'args' -and $server.args) {
+            $serverValues += @($server.args)
+        }
+        if ($server.PSObject.Properties.Name -contains 'url' -and $server.url) {
+            $serverValues += $server.url
+        }
+
+        $hasPlaceholder = $false
+        foreach ($value in $serverValues) {
+            foreach ($placeholder in $placeholders) {
+                if ($value -like "*$placeholder*") { $hasPlaceholder = $true; break }
+            }
+            if ($hasPlaceholder) { break }
+        }
+
+        if ($hasPlaceholder) {
+            Write-Warn "Skipping MCP server '$($server.name)' (contains placeholder value — edit config.json and re-run)"
+            continue
+        }
+
         $serverConfig = if ($server.type -eq "local") {
             [PSCustomObject]@{
                 tools   = @("*")
@@ -382,6 +408,186 @@ function Register-MCPServers {
 
     $mcpConfig | ConvertTo-Json -Depth 10 | Out-File -FilePath $mcpConfigPath -Force -Encoding UTF8
     Write-Success "MCP servers written to $mcpConfigPath"
+}
+
+function Install-VisualStudio {
+    if ($null -eq $config.windows.visual_studio) {
+        return
+    }
+
+    $vs = $config.windows.visual_studio
+    $edition = $vs.edition
+    $url = $vs.bootstrapper_url
+    $installPath = $vs.install_path
+
+    if ((Test-ShouldSkipInstalled) -and $installPath -and (Test-Path $installPath)) {
+        Write-Success "Already installed: Visual Studio $edition ($installPath)"
+        return
+    }
+
+    Write-Info "Installing Visual Studio $edition from $url ..."
+
+    $bootstrapper = Join-Path $env:TEMP "vs_$($edition.ToLower()).exe"
+
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $bootstrapper -UseBasicParsing
+    } catch {
+        $script:failedItems += "Visual Studio: bootstrapper download failed"
+        Write-Err "Failed to download Visual Studio bootstrapper: $_"
+        return
+    }
+
+    # Build bootstrapper arguments: --add per workload, plus standard install flags
+    $bootstrapperArgs = @()
+    foreach ($workload in $vs.workloads) {
+        $bootstrapperArgs += "--add"
+        $bootstrapperArgs += $workload
+    }
+    if ($vs.include_recommended) { $bootstrapperArgs += "--includeRecommended" }
+    $bootstrapperArgs += "--quiet"
+    $bootstrapperArgs += "--wait"
+    $bootstrapperArgs += "--norestart"
+    $bootstrapperArgs += "--nocache"
+
+    Write-Info "Running Visual Studio installer (this may take a while)..."
+    try {
+        $proc = Start-Process -FilePath $bootstrapper -ArgumentList $bootstrapperArgs -Wait -PassThru -NoNewWindow
+        # Per Microsoft docs: 0 = success, 3010 = success but reboot required, 1602/1603 = user/install error
+        if ($proc.ExitCode -eq 0) {
+            Write-Success "Visual Studio $edition installed"
+        } elseif ($proc.ExitCode -eq 3010) {
+            Write-Success "Visual Studio $edition installed (reboot required)"
+        } else {
+            $script:failedItems += "Visual Studio: installer exit $($proc.ExitCode)"
+            Write-Err "Visual Studio installer returned exit code $($proc.ExitCode)"
+        }
+    } catch {
+        $script:failedItems += "Visual Studio: $_"
+        Write-Err "Failed to run Visual Studio installer: $_"
+    } finally {
+        Remove-Item $bootstrapper -ErrorAction SilentlyContinue
+    }
+}
+
+function Install-Aspire {
+    if ((Test-ShouldSkipInstalled) -and (Get-Command aspire -ErrorAction SilentlyContinue)) {
+        Write-Success "Already installed: aspire CLI"
+        return
+    }
+
+    Write-Info "Installing Aspire CLI..."
+
+    $tmp = Join-Path $env:TEMP "aspire-install.ps1"
+
+    try {
+        Invoke-WebRequest -Uri "https://aspire.dev/install.ps1" -OutFile $tmp -UseBasicParsing
+    } catch {
+        $script:failedItems += "aspire CLI: download failed"
+        Write-Err "Failed to download Aspire installer: $_"
+        return
+    }
+
+    Invoke-SafeInstall -Description "aspire CLI: install" -Action {
+        & powershell -NoProfile -ExecutionPolicy Bypass -File $tmp 2>&1
+    }
+
+    Remove-Item $tmp -ErrorAction SilentlyContinue
+
+    # Refresh PATH from system + user, and make aspire available in this session
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+    $aspireBin = Join-Path $env:USERPROFILE ".aspire\bin"
+    if ((Test-Path $aspireBin) -and ($env:Path -notlike "*$aspireBin*")) {
+        $env:Path = "$aspireBin;$env:Path"
+    }
+
+    if (Get-Command aspire -ErrorAction SilentlyContinue) {
+        Write-Success "Aspire CLI installed"
+    } else {
+        Write-Warn "Aspire installer ran but 'aspire' is not yet on PATH"
+    }
+}
+
+function Install-NpmGlobals {
+    $packages = $config.shared.npm_global_packages
+    if ($null -eq $packages -or $packages.Count -eq 0) {
+        return
+    }
+
+    # Refresh PATH so npm (installed by winget via OpenJS.NodeJS.LTS) is visible
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+
+    if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+        Write-Warn "npm not available on PATH; skipping global npm package install"
+        $script:failedItems += "npm global packages: npm not on PATH"
+        return
+    }
+
+    Write-Info "Installing npm packages globally..."
+    foreach ($pkg in $packages) {
+        Invoke-SafeInstall -Description "npm global: $pkg" -Action {
+            npm install -g $pkg 2>&1
+        }
+    }
+}
+
+function Install-CopilotApp {
+    if ($null -eq $config.windows.copilot_app) {
+        return
+    }
+
+    $url = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
+        $config.windows.copilot_app.url_arm64
+    } else {
+        $config.windows.copilot_app.url_x64
+    }
+
+    # Common install locations the desktop app may use
+    $installedMarkers = @(
+        (Join-Path $env:LOCALAPPDATA "Programs\github-copilot"),
+        (Join-Path $env:LOCALAPPDATA "Programs\GitHubCopilot"),
+        (Join-Path $env:LOCALAPPDATA "Programs\GitHub Copilot")
+    )
+    if (Test-ShouldSkipInstalled) {
+        foreach ($m in $installedMarkers) {
+            if (Test-Path $m) {
+                Write-Success "Already installed: GitHub Copilot app ($m)"
+                return
+            }
+        }
+    }
+
+    Write-Info "Downloading GitHub Copilot app from $url ..."
+    $installer = Join-Path $env:TEMP "GitHub-Copilot-setup.exe"
+
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $installer -UseBasicParsing
+    } catch {
+        $script:failedItems += "GitHub Copilot app: download failed"
+        Write-Err "Failed to download GitHub Copilot app: $_"
+        return
+    }
+
+    Write-Info "Running GitHub Copilot app installer (silent)..."
+    try {
+        $proc = Start-Process -FilePath $installer -ArgumentList '/S' -Wait -PassThru
+        if ($proc.ExitCode -ne 0) {
+            Write-Warn "Silent install returned exit code $($proc.ExitCode); retrying interactively..."
+            $proc2 = Start-Process -FilePath $installer -Wait -PassThru
+            if ($proc2.ExitCode -ne 0) {
+                $script:failedItems += "GitHub Copilot app: installer exit $($proc2.ExitCode)"
+                Write-Err "GitHub Copilot app installer failed (exit $($proc2.ExitCode))"
+            } else {
+                Write-Success "GitHub Copilot app installed"
+            }
+        } else {
+            Write-Success "GitHub Copilot app installed"
+        }
+    } catch {
+        $script:failedItems += "GitHub Copilot app: $_"
+        Write-Err "Failed to run GitHub Copilot app installer: $_"
+    } finally {
+        Remove-Item $installer -ErrorAction SilentlyContinue
+    }
 }
 
 function New-DemoLoader {
@@ -435,6 +641,9 @@ Import-Config
 
 # Install packages
 Install-Packages
+Install-VisualStudio
+Install-Aspire
+Install-NpmGlobals
 Set-VLCConfiguration
 
 # Launch post-install apps
@@ -442,6 +651,7 @@ Start-PostInstallApps
 
 # Setup environments
 Connect-GH
+Install-CopilotApp
 Copy-Repos
 Install-PWAs
 

--- a/setup.sh
+++ b/setup.sh
@@ -624,8 +624,8 @@ create_demo_loader
 
 # Print summary and finish
 print_summary
-if [[ ${#FAILED_ITEMS[@]} -gt 0 ]]; then
-    log_warn "Script completed with ${#FAILED_ITEMS[@]} failure(s)"
+if [[ ${#failed_items[@]} -gt 0 ]]; then
+    log_warn "Script completed with ${#failed_items[@]} failure(s)"
     exit 1
 fi
 log_success "Script completed successfully"

--- a/setup.sh
+++ b/setup.sh
@@ -403,26 +403,158 @@ configure_editors() {
     done
 }
 
-# Returns 0 if any arg/url of the MCP server at the given index matches a placeholder
-mcp_server_has_placeholder() {
-    local idx="$1"
-
+# Returns 0 if any of the given values (passed as args) contains a placeholder
+mcp_values_have_placeholder() {
     if [[ ${#placeholders[@]} -eq 0 ]]; then
         return 1
     fi
 
-    local values
-    values=$(jq -r ".shared.mcp_servers[$idx] | (.args // []) + [(.url // empty)] | .[]" "$CONFIG_FILE")
-
-    while IFS= read -r value; do
+    for value in "$@"; do
         for placeholder in "${placeholders[@]}"; do
             if [[ "$value" == *"$placeholder"* ]]; then
                 return 0
             fi
         done
-    done <<< "$values"
+    done
 
     return 1
+}
+
+# Path to the per-machine setup state file (separate from checked-in config)
+setup_state_path() {
+    local copilot_home="${COPILOT_HOME:-$HOME/.copilot}"
+    echo "$copilot_home/machine-setup-state.json"
+}
+
+# Reads the setup state file into the global ADO_ORG_VALUE / ADO_ORG_MODE vars.
+# Tolerates missing or corrupt state — warns and continues with defaults.
+load_setup_state() {
+    ADO_ORG_VALUE=""
+    ADO_ORG_MODE=""
+
+    local state_path
+    state_path=$(setup_state_path)
+    [[ -f "$state_path" ]] || return 0
+
+    if ! jq empty "$state_path" 2>/dev/null; then
+        log_warn "Setup state file at $state_path is not valid JSON; ignoring"
+        return 0
+    fi
+
+    ADO_ORG_VALUE=$(jq -r '.inputs.azure_devops_org.value // ""' "$state_path")
+    ADO_ORG_MODE=$(jq -r '.inputs.azure_devops_org.mode // ""' "$state_path")
+}
+
+# Atomically writes the current ADO_ORG_VALUE / ADO_ORG_MODE to the state file.
+save_setup_state() {
+    local state_path
+    state_path=$(setup_state_path)
+    local copilot_home="${COPILOT_HOME:-$HOME/.copilot}"
+    mkdir -p "$copilot_home"
+
+    local existing='{}'
+    if [[ -f "$state_path" ]] && jq empty "$state_path" 2>/dev/null; then
+        existing=$(cat "$state_path")
+    fi
+
+    local updated
+    updated=$(echo "$existing" | jq \
+        --arg value "$ADO_ORG_VALUE" \
+        --arg mode "$ADO_ORG_MODE" \
+        '.inputs //= {} | .inputs.azure_devops_org = {value: $value, mode: $mode}')
+
+    local tmp="${state_path}.tmp.$$"
+    printf '%s\n' "$updated" > "$tmp" || { log_warn "Failed to write setup state"; rm -f "$tmp"; return 0; }
+    if ! jq empty "$tmp" 2>/dev/null; then
+        log_warn "Setup state write produced invalid JSON; discarding"
+        rm -f "$tmp"
+        return 0
+    fi
+    mv "$tmp" "$state_path"
+    chmod 600 "$state_path" 2>/dev/null || true
+}
+
+# Prompts (when TTY) for inputs that vary per machine. Sets ADO_ORG_VALUE
+# and ADO_ORG_MODE ("configured", "skip", or "" = not answered).
+#
+# Precedence:
+#   1. ADO_ORG env var (if set, including empty = explicit skip)
+#   2. Interactive prompt with cached value as default
+#   3. Cached value (when non-interactive)
+#   4. Skip
+prompt_for_inputs() {
+    load_setup_state
+
+    # 1. Env var override (always wins; explicit empty = skip)
+    if [[ -n "${ADO_ORG+x}" ]]; then
+        local trimmed
+        trimmed="${ADO_ORG#"${ADO_ORG%%[![:space:]]*}"}"
+        trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+        if [[ -z "$trimmed" ]]; then
+            ADO_ORG_VALUE=""
+            ADO_ORG_MODE="skip"
+            log_info "ADO_ORG is empty in env; Azure DevOps MCP server will be skipped"
+        else
+            ADO_ORG_VALUE="$trimmed"
+            ADO_ORG_MODE="configured"
+            log_info "Using Azure DevOps org from ADO_ORG env var: $ADO_ORG_VALUE"
+        fi
+        save_setup_state
+        return 0
+    fi
+
+    # 2. Interactive prompt (only when both stdin and stdout are TTYs)
+    if [[ -t 0 ]] && [[ -t 1 ]]; then
+        local prompt_label="Azure DevOps organization name"
+        local hint
+        if [[ "$ADO_ORG_MODE" == "configured" ]] && [[ -n "$ADO_ORG_VALUE" ]]; then
+            hint="[current: $ADO_ORG_VALUE; Enter to keep, '-' to clear]"
+        else
+            hint="(leave blank to skip the Azure DevOps MCP server)"
+        fi
+
+        local answer
+        printf '%s %s\n> ' "$prompt_label" "$hint" >&2
+        IFS= read -r answer || answer=""
+
+        local trimmed
+        trimmed="${answer#"${answer%%[![:space:]]*}"}"
+        trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+
+        if [[ -z "$trimmed" ]]; then
+            if [[ "$ADO_ORG_MODE" == "configured" ]] && [[ -n "$ADO_ORG_VALUE" ]]; then
+                log_info "Keeping cached Azure DevOps org: $ADO_ORG_VALUE"
+            else
+                ADO_ORG_VALUE=""
+                ADO_ORG_MODE="skip"
+                log_info "Azure DevOps MCP server will be skipped"
+            fi
+        elif [[ "$trimmed" == "-" ]]; then
+            ADO_ORG_VALUE=""
+            ADO_ORG_MODE="skip"
+            log_info "Cleared Azure DevOps org; the MCP server will be skipped"
+        else
+            if [[ "$trimmed" == *" "* ]] || [[ "$trimmed" == *"/"* ]] || [[ "$trimmed" == *":"* ]]; then
+                log_warn "Azure DevOps org '$trimmed' contains unusual characters; accepting anyway"
+            fi
+            ADO_ORG_VALUE="$trimmed"
+            ADO_ORG_MODE="configured"
+            log_success "Azure DevOps org set to: $ADO_ORG_VALUE"
+        fi
+        save_setup_state
+        return 0
+    fi
+
+    # 3. Non-interactive: fall back to cached value if present
+    if [[ "$ADO_ORG_MODE" == "configured" ]] && [[ -n "$ADO_ORG_VALUE" ]]; then
+        log_info "Non-interactive run; using cached Azure DevOps org: $ADO_ORG_VALUE"
+    elif [[ "$ADO_ORG_MODE" == "skip" ]]; then
+        log_info "Non-interactive run; cached state says skip Azure DevOps MCP server"
+    else
+        log_info "Non-interactive run with no cached value; Azure DevOps MCP server will be skipped"
+        ADO_ORG_VALUE=""
+        ADO_ORG_MODE="skip"
+    fi
 }
 
 # Registers MCP servers in Copilot CLI config
@@ -451,8 +583,9 @@ register_mcp_servers() {
         name=$(jq -r ".shared.mcp_servers[$i].name" "$CONFIG_FILE")
         type=$(jq -r ".shared.mcp_servers[$i].type" "$CONFIG_FILE")
 
-        if mcp_server_has_placeholder "$i"; then
-            log_warn "Skipping MCP server '$name' (contains placeholder value — edit config.json and re-run)"
+        # Explicit skip: azure-devops requires a configured org
+        if [[ "$name" == "azure-devops" ]] && [[ "$ADO_ORG_MODE" != "configured" || -z "$ADO_ORG_VALUE" ]]; then
+            log_warn "Skipping MCP server 'azure-devops' (no Azure DevOps org configured — re-run setup to provide one or set ADO_ORG)"
             continue
         fi
 
@@ -460,6 +593,23 @@ register_mcp_servers() {
             local command args
             command=$(jq -r ".shared.mcp_servers[$i].command" "$CONFIG_FILE")
             args=$(jq -c ".shared.mcp_servers[$i].args" "$CONFIG_FILE")
+
+            # Substitute placeholders in args using known inputs
+            if [[ -n "$ADO_ORG_VALUE" ]]; then
+                args=$(echo "$args" | jq --arg v "$ADO_ORG_VALUE" 'map(if . == "<YOUR-ADO-ORG>" then $v else . end)')
+            fi
+
+            # Defensive backstop: refuse to register if any placeholder slipped through
+            local arg_strings
+            arg_strings=$(echo "$args" | jq -r '.[]')
+            local has_ph=0
+            while IFS= read -r v; do
+                if mcp_values_have_placeholder "$v"; then has_ph=1; break; fi
+            done <<< "$arg_strings"
+            if [[ "$has_ph" -eq 1 ]]; then
+                log_warn "Skipping MCP server '$name' (placeholder still present after substitution)"
+                continue
+            fi
 
             existing=$(echo "$existing" | jq \
                 --arg name "$name" \
@@ -470,6 +620,11 @@ register_mcp_servers() {
         else
             local url
             url=$(jq -r ".shared.mcp_servers[$i].url" "$CONFIG_FILE")
+
+            if mcp_values_have_placeholder "$url"; then
+                log_warn "Skipping MCP server '$name' (URL still contains a placeholder)"
+                continue
+            fi
 
             existing=$(echo "$existing" | jq \
                 --arg name "$name" \
@@ -595,6 +750,9 @@ install_npm_globals() {
 install_homebrew
 install_jq
 load_config
+
+# Prompt for per-machine inputs early, so the user isn't stuck waiting later
+prompt_for_inputs
 
 # Install packages
 install_packages

--- a/setup.sh
+++ b/setup.sh
@@ -134,6 +134,12 @@ load_config() {
 
     demo_sites=()
     while IFS= read -r line; do demo_sites+=("$line"); done < <(jq -r '.shared.demo_sites[]' "$CONFIG_FILE")
+
+    placeholders=()
+    while IFS= read -r line; do placeholders+=("$line"); done < <(jq -r '.shared.placeholders // [] | .[]' "$CONFIG_FILE")
+
+    npm_global_packages=()
+    while IFS= read -r line; do npm_global_packages+=("$line"); done < <(jq -r '.shared.npm_global_packages // [] | .[]' "$CONFIG_FILE")
 }
 
 # ----------------------------------------
@@ -397,6 +403,28 @@ configure_editors() {
     done
 }
 
+# Returns 0 if any arg/url of the MCP server at the given index matches a placeholder
+mcp_server_has_placeholder() {
+    local idx="$1"
+
+    if [[ ${#placeholders[@]} -eq 0 ]]; then
+        return 1
+    fi
+
+    local values
+    values=$(jq -r ".shared.mcp_servers[$idx] | (.args // []) + [(.url // empty)] | .[]" "$CONFIG_FILE")
+
+    while IFS= read -r value; do
+        for placeholder in "${placeholders[@]}"; do
+            if [[ "$value" == *"$placeholder"* ]]; then
+                return 0
+            fi
+        done
+    done <<< "$values"
+
+    return 1
+}
+
 # Registers MCP servers in Copilot CLI config
 register_mcp_servers() {
     local copilot_home="${COPILOT_HOME:-$HOME/.copilot}"
@@ -422,6 +450,11 @@ register_mcp_servers() {
         local name type
         name=$(jq -r ".shared.mcp_servers[$i].name" "$CONFIG_FILE")
         type=$(jq -r ".shared.mcp_servers[$i].type" "$CONFIG_FILE")
+
+        if mcp_server_has_placeholder "$i"; then
+            log_warn "Skipping MCP server '$name' (contains placeholder value — edit config.json and re-run)"
+            continue
+        fi
 
         if [[ "$type" == "local" ]]; then
             local command args
@@ -450,6 +483,50 @@ register_mcp_servers() {
 
     echo "$existing" | jq . > "$mcp_config"
     log_success "MCP servers written to $mcp_config"
+}
+
+# Installs the Microsoft Aspire CLI via the official installer script
+install_aspire() {
+    if should_skip_installed && command -v aspire &> /dev/null; then
+        log_success "Already installed: aspire CLI"
+        return
+    fi
+
+    log_info "Installing Aspire CLI..."
+
+    local tmp
+    tmp=$(mktemp)
+    if ! curl -fsSL https://aspire.dev/install.sh -o "$tmp"; then
+        failed_items+=("aspire CLI: download failed")
+        log_error "Failed to download Aspire installer"
+        rm -f "$tmp"
+        return
+    fi
+
+    try_install "aspire CLI: install" bash "$tmp"
+    rm -f "$tmp"
+
+    # Make aspire available in this shell + persist for future shells
+    local aspire_bin="$HOME/.aspire/bin"
+    if [[ -d "$aspire_bin" ]]; then
+        export PATH="$aspire_bin:$PATH"
+
+        local shell_rc="$HOME/.zshrc"
+        if ! grep -q '\.aspire/bin' "$shell_rc" 2>/dev/null; then
+            log_info "Adding Aspire CLI to PATH in $shell_rc..."
+            {
+                echo ''
+                echo '# Aspire CLI'
+                echo 'export PATH="$HOME/.aspire/bin:$PATH"'
+            } >> "$shell_rc"
+        fi
+    fi
+
+    if command -v aspire &> /dev/null; then
+        log_success "Aspire CLI installed"
+    else
+        log_warn "Aspire installer ran but 'aspire' is not yet on PATH"
+    fi
 }
 
 # Creates a demo loader script to launch all required applications and sites
@@ -485,6 +562,35 @@ EOF
 # Main Execution
 # ----------------------------------------
 
+# Install npm packages globally (so MCP servers don't need npx at runtime)
+install_npm_globals() {
+    if [[ ${#npm_global_packages[@]} -eq 0 ]]; then
+        return
+    fi
+
+    # nvm-installed node may not be on PATH yet in this shell; source nvm if available
+    if ! command -v npm &> /dev/null; then
+        export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+        local nvm_sh
+        nvm_sh="$(brew --prefix nvm 2>/dev/null)/nvm.sh"
+        if [[ -s "$nvm_sh" ]]; then
+            # shellcheck disable=SC1090
+            . "$nvm_sh"
+        fi
+    fi
+
+    if ! command -v npm &> /dev/null; then
+        log_warn "npm not available; skipping global npm package install"
+        failed_items+=("npm global packages: npm not on PATH")
+        return
+    fi
+
+    log_info "Installing npm packages globally..."
+    for pkg in "${npm_global_packages[@]}"; do
+        try_install "npm global: $pkg" npm install -g "$pkg"
+    done
+}
+
 # Bootstrap: install homebrew and jq before loading config
 install_homebrew
 install_jq
@@ -492,6 +598,8 @@ load_config
 
 # Install packages
 install_packages
+install_aspire
+install_npm_globals
 configure_vlc
 
 # Launch post-install apps (e.g., Docker)


### PR DESCRIPTION
## Summary

Extends the macOS and Windows machine-setup scripts with additional developer tooling and MCP servers commonly needed at the booth, keeping all platform-agnostic data driven from `config.json`.

## What's new

### Tooling
- **Visual Studio 2026 Enterprise** (Windows): installed via the official Microsoft bootstrapper (`aka.ms/vs/stable/vs_enterprise.exe`). Workloads: `NetWeb`, `Azure`, `ManagedDesktop`, with `--includeRecommended`. Exit codes `0` and `3010` are both treated as success.
- **Microsoft Aspire** (both OSes): installed via the official `https://aspire.dev/install.{sh,ps1}` scripts; `~/.aspire/bin` is added to PATH for the current session and persisted to the shell profile.
- **GitHub Copilot CLI**
  - macOS: installed via the `copilot-cli` Homebrew cask (already in `mac.packages.casks`).
  - Windows: installed via `winget install GitHub.Copilot`.
- **GitHub Copilot Desktop App**
  - macOS: installed via the `github-copilot-app` Homebrew cask.
  - Windows: downloaded from `github/app`'s `releases/latest/download/...` URLs (arch-aware, ARM64 vs x64), silent `/S` install with a fallback to interactive on non-zero exit.
- **Node.js LTS**: via nvm on macOS (already in place) and `OpenJS.NodeJS.LTS` on Windows; required by the npm-distributed MCP servers below.

### MCP servers (registered in `~/.copilot/mcp-config.json`)
- **Aspire** (`aspire agent mcp`)
- **Azure DevOps** (`mcp-server-azuredevops <YOUR-ADO-ORG>`)
- **Azure** (`azmcp server start`), sourced from `microsoft/mcp/servers/Azure.Mcp.Server`.

Microsoft Learn MCP and the Playwright / Astro / Svelte docs MCP servers remain configured as before.

### MCP server installation strategy
Node-based MCP servers (`@playwright/mcp`, `@azure/mcp`, `@azure-devops/mcp`) are installed globally via `npm install -g` during setup, and the `mcp-config.json` entries invoke the installed binaries (`playwright-mcp`, `azmcp`, `mcp-server-azuredevops`) directly rather than going through `npx -y ...@latest` at every Copilot CLI launch. This gives faster cold starts, predictable versions, and no network requirement after the initial install. The package list lives in `shared.npm_global_packages`.

### Placeholder handling
New `shared.placeholders` array in `config.json` (currently `["<YOUR-ADO-ORG>"]`). Both `register_mcp_servers` (bash) and `Register-MCPServers` (PowerShell) skip any server whose args/url still contain a placeholder, with a warning log, so a not-yet-configured Azure DevOps entry never lands in `mcp-config.json`.

## Files changed
- `config.json`: new MCP servers, placeholders, `npm_global_packages`, casks, Windows packages, `visual_studio` and `copilot_app` blocks.
- `setup.sh`: `install_aspire`, `install_npm_globals`, placeholder-aware MCP registration.
- `setup.ps1`: `Install-VisualStudio`, `Install-Aspire`, `Install-NpmGlobals`, `Install-CopilotApp`, placeholder-aware MCP registration.
- `README.md`: features list and new post-setup configuration section (ADO org placeholder, VS bootstrapper / Insiders / workload customization).

## Post-setup steps for the user
1. Replace `<YOUR-ADO-ORG>` in `~/.copilot/mcp-config.json` with your Azure DevOps org (or update `config.json` and re-run setup).
2. To switch VS to Insiders, change `windows.visual_studio.bootstrapper_url` to `https://aka.ms/vs/insiders/vs_enterprise.exe`. Workloads and edition are also config-driven.

## Validation
- `jq . config.json` passes.
- `bash -n setup.sh` passes.
- `setup.ps1` reviewed visually (no PowerShell available in the dev environment); avoided shadowing the automatic `$args` variable in `Install-VisualStudio`.