### PR TITLE
Add interactive sequential GitHub sign-in checklist

### DIFF
--- a/config.json
+++ b/config.json
@@ -100,6 +100,7 @@
         "github-copilot-app"
       ],
       "formulas": [
+        "git",
         "gh",
         "python@3.14",
         "nvm"
@@ -123,6 +124,7 @@
   },
   "windows": {
     "packages": [
+      "Git.Git",
       "Microsoft.VisualStudioCode",
       "Microsoft.VisualStudioCode.Insiders",
       "Microsoft.WindowsTerminal",

--- a/setup.ps1
+++ b/setup.ps1
@@ -19,6 +19,10 @@
     - Internet connection
 #>
 
+param(
+    [switch]$SkipSignIn
+)
+
 # ----------------------------------------
 # Constants
 # ----------------------------------------
@@ -457,6 +461,179 @@ function Connect-GH {
     }
 }
 
+function Invoke-SignInStep {
+    param(
+        [int]$Index,
+        [int]$Total,
+        [string]$Name,
+        [scriptblock]$Launch,
+        [string]$ManualHint
+    )
+
+    Write-Host ""
+    Write-Host "[$Index/$Total] $Name" -ForegroundColor Cyan
+
+    $launched = $false
+    try {
+        & $Launch
+        $launched = $true
+    } catch {
+        Write-Warn "Could not launch $Name automatically: $_"
+        if ($ManualHint) { Write-Warn "Manual step: $ManualHint" }
+    }
+
+    if ($launched -and $ManualHint) {
+        Write-Info $ManualHint
+    }
+
+    [void](Read-Host "  -> Press Enter once you've signed in to $Name (or to skip)")
+    Write-Success "$Name - confirmed"
+}
+
+function Start-SignInChecklist {
+    if ($SkipSignIn) {
+        Write-Info "Skipping sign-in checklist (-SkipSignIn was specified)."
+        return
+    }
+
+    # Only run interactively (stdin not redirected); matches Read-SetupInputs convention.
+    $interactive = $true
+    try {
+        if ([Console]::IsInputRedirected) { $interactive = $false }
+    } catch {
+        # Some hosts don't expose this; assume interactive and let Read-Host handle it.
+    }
+    if (-not $interactive) {
+        Write-Info "Non-interactive session detected; skipping sign-in checklist."
+        return
+    }
+
+    Write-Host ""
+    Write-Host "========================================" -ForegroundColor Cyan
+    Write-Host "GitHub sign-in checklist"                 -ForegroundColor Cyan
+    Write-Host "Sign in to each surface one at a time."    -ForegroundColor Cyan
+    Write-Host "Order matters: the browser session is the source of truth others inherit." -ForegroundColor Cyan
+    Write-Host "========================================" -ForegroundColor Cyan
+
+    if (-not [string]::IsNullOrWhiteSpace($Env:DEMO_GH_USER)) {
+        Write-Info "Expected demo account: $Env:DEMO_GH_USER  (verify every surface signs in as this user)"
+    } else {
+        Write-Info "Tip: set DEMO_GH_USER to display the expected demo account here."
+    }
+
+    $total = 6
+
+    # ---- Step 1: Web browser (establish the browser session first) ----
+    Invoke-SignInStep -Index 1 -Total $total -Name "Web browser (github.com)" `
+        -ManualHint "Open https://github.com/login and sign in as the demo account." `
+        -Launch {
+            Start-Process "https://github.com/login" | Out-Null
+        }
+
+    # ---- Step 2: GitHub CLI (skip if Connect-GH already authenticated) ----
+    $ghAuthed = $false
+    if (Get-Command gh -ErrorAction SilentlyContinue) {
+        gh auth status 2>&1 | Out-Null
+        if ($LASTEXITCODE -eq 0) { $ghAuthed = $true }
+    }
+
+    if ($ghAuthed) {
+        Write-Host ""
+        Write-Host "[2/$total] GitHub CLI (gh)" -ForegroundColor Cyan
+        Write-Success "GitHub CLI - already authenticated, skipping"
+    } else {
+        Invoke-SignInStep -Index 2 -Total $total -Name "GitHub CLI (gh)" `
+            -ManualHint "Run 'gh auth login --web' and complete the device flow in the browser." `
+            -Launch {
+                if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { throw "gh not found on PATH" }
+                gh auth login --web
+                if ($LASTEXITCODE -ne 0) { throw "gh auth login exited with code $LASTEXITCODE" }
+            }
+    }
+
+    # ---- Step 3: Copilot CLI (first-run device flow via /login) ----
+    Invoke-SignInStep -Index 3 -Total $total -Name "Copilot CLI (copilot)" `
+        -ManualHint "In the Copilot CLI window, run the '/login' slash command to authenticate." `
+        -Launch {
+            $copilotCmd = Get-Command copilot -ErrorAction SilentlyContinue
+            if ($null -eq $copilotCmd) { throw "copilot not found on PATH" }
+            # Launch in a persistent window so the user can run /login and see any errors.
+            Start-Process powershell.exe -ArgumentList @('-NoExit', '-Command', "& '$($copilotCmd.Source)'") | Out-Null
+        }
+
+    # ---- Step 4: VS Code ----
+    Invoke-SignInStep -Index 4 -Total $total -Name "VS Code" `
+        -ManualHint "If Copilot doesn't prompt, sign in via the Accounts menu (bottom-left gear/avatar)." `
+        -Launch {
+            if (-not (Get-Command code -ErrorAction SilentlyContinue)) { throw "code (VS Code) not found on PATH" }
+            & code --command "github.copilot.signIn" 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw "code exited with code $LASTEXITCODE" }
+        }
+
+    # ---- Step 5: VS Code Insiders ----
+    Invoke-SignInStep -Index 5 -Total $total -Name "VS Code Insiders" `
+        -ManualHint "If Copilot doesn't prompt, sign in via the Accounts menu (bottom-left gear/avatar)." `
+        -Launch {
+            if (-not (Get-Command code-insiders -ErrorAction SilentlyContinue)) { throw "code-insiders not found on PATH" }
+            & code-insiders --command "github.copilot.signIn" 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw "code-insiders exited with code $LASTEXITCODE" }
+        }
+
+    # ---- Step 6: Copilot desktop app ----
+    Invoke-SignInStep -Index 6 -Total $total -Name "Copilot app (desktop)" `
+        -ManualHint "Launch the GitHub Copilot app from the Start Menu and sign in inside the app." `
+        -Launch {
+            $markerDirs = @(
+                (Join-Path $env:LOCALAPPDATA "Programs\github-copilot"),
+                (Join-Path $env:LOCALAPPDATA "Programs\GitHubCopilot"),
+                (Join-Path $env:LOCALAPPDATA "Programs\GitHub Copilot")
+            )
+
+            $exe = $null
+
+            # Prefer well-known executable names before falling back to a filtered search.
+            $preferredNames = @('GitHub Copilot.exe', 'GitHubCopilot.exe', 'Copilot.exe')
+            foreach ($dir in $markerDirs) {
+                if (-not (Test-Path $dir)) { continue }
+                foreach ($name in $preferredNames) {
+                    $candidate = Join-Path $dir $name
+                    if (Test-Path $candidate) { $exe = $candidate; break }
+                }
+                if ($exe) { break }
+            }
+
+            if ($null -eq $exe) {
+                foreach ($dir in $markerDirs) {
+                    if (-not (Test-Path $dir)) { continue }
+                    $match = Get-ChildItem -Path $dir -Filter *.exe -Recurse -File -ErrorAction SilentlyContinue |
+                        Where-Object { $_.Name -notmatch '(?i)(unins|update|setup|crash|helper|elevate)' } |
+                        Select-Object -First 1
+                    if ($match) { $exe = $match.FullName; break }
+                }
+            }
+
+            if ($null -eq $exe) {
+                # Fall back to a Start Menu shortcut if the executable wasn't found.
+                $startMenuDirs = @(
+                    (Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs"),
+                    (Join-Path $env:ProgramData "Microsoft\Windows\Start Menu\Programs")
+                )
+                foreach ($sm in $startMenuDirs) {
+                    if (-not (Test-Path $sm)) { continue }
+                    $lnk = Get-ChildItem -Path $sm -Filter "*GitHub*Copilot*.lnk" -Recurse -File -ErrorAction SilentlyContinue |
+                        Select-Object -First 1
+                    if ($lnk) { $exe = $lnk.FullName; break }
+                }
+            }
+
+            if ($null -eq $exe) { throw "Copilot desktop app executable not found" }
+            Start-Process $exe | Out-Null
+        }
+
+    Write-Host ""
+    Write-Success "Sign-in checklist complete."
+}
+
 function Copy-Repos {
     $reposDir = Join-Path $env:USERPROFILE "repos"
 
@@ -833,6 +1010,9 @@ Install-PWAs
 
 # Install extensions and configure themes
 Initialize-Editors
+
+# Guided GitHub sign-in across all surfaces (browser first so others inherit the session)
+Start-SignInChecklist
 
 # Register MCP servers for Copilot CLI
 Register-MCPServers

--- a/setup.ps1
+++ b/setup.ps1
@@ -461,6 +461,16 @@ function Connect-GH {
     }
 }
 
+# Returns the install-marker directories the GitHub Copilot desktop app may use.
+# Shared by Install-CopilotApp and the sign-in checklist so the two stay in sync.
+function Get-CopilotAppMarkerDir {
+    @(
+        (Join-Path $env:LOCALAPPDATA "Programs\github-copilot"),
+        (Join-Path $env:LOCALAPPDATA "Programs\GitHubCopilot"),
+        (Join-Path $env:LOCALAPPDATA "Programs\GitHub Copilot")
+    )
+}
+
 function Invoke-SignInStep {
     param(
         [int]$Index,
@@ -583,11 +593,7 @@ function Start-SignInChecklist {
     Invoke-SignInStep -Index 6 -Total $total -Name "Copilot app (desktop)" `
         -ManualHint "Launch the GitHub Copilot app from the Start Menu and sign in inside the app." `
         -Launch {
-            $markerDirs = @(
-                (Join-Path $env:LOCALAPPDATA "Programs\github-copilot"),
-                (Join-Path $env:LOCALAPPDATA "Programs\GitHubCopilot"),
-                (Join-Path $env:LOCALAPPDATA "Programs\GitHub Copilot")
-            )
+            $markerDirs = Get-CopilotAppMarkerDir
 
             $exe = $null
 
@@ -892,11 +898,7 @@ function Install-CopilotApp {
     }
 
     # Common install locations the desktop app may use
-    $installedMarkers = @(
-        (Join-Path $env:LOCALAPPDATA "Programs\github-copilot"),
-        (Join-Path $env:LOCALAPPDATA "Programs\GitHubCopilot"),
-        (Join-Path $env:LOCALAPPDATA "Programs\GitHub Copilot")
-    )
+    $installedMarkers = Get-CopilotAppMarkerDir
     if (Test-ShouldSkipInstalled) {
         foreach ($m in $installedMarkers) {
             if (Test-Path $m) {
@@ -994,7 +996,6 @@ Read-SetupInputs
 
 # Install packages
 Install-Packages
-Install-VisualStudio
 Install-Aspire
 Install-NpmGlobals
 Set-VLCConfiguration
@@ -1011,11 +1012,15 @@ Install-PWAs
 # Install extensions and configure themes
 Initialize-Editors
 
+# Register MCP servers for Copilot CLI
+Register-MCPServers
+
 # Guided GitHub sign-in across all surfaces (browser first so others inherit the session)
 Start-SignInChecklist
 
-# Register MCP servers for Copilot CLI
-Register-MCPServers
+# Visual Studio Enterprise install is long and blocking, so run it last (after the
+# quick interactive steps) so the user can walk away while it completes.
+Install-VisualStudio
 
 # Create demo loader script
 New-DemoLoader

--- a/setup.ps1
+++ b/setup.ps1
@@ -290,6 +290,20 @@ function Install-Packages {
     # Refresh PATH so newly installed tools are available
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
+    # Defensive fallback: Git for Windows installs to C:\Program Files\Git\cmd.
+    # If the PATH refresh above didn't surface it, add it so git-dependent steps
+    # (gh git protocol, gh extensions) can find git.
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        $gitCmd = "C:\Program Files\Git\cmd"
+        if (Test-Path (Join-Path $gitCmd "git.exe")) {
+            $env:Path = "$gitCmd;$env:Path"
+            Write-Info "Added $gitCmd to PATH for this session"
+        }
+        else {
+            Write-Warn "git not found on PATH after install; git-dependent steps may fail"
+        }
+    }
+
     Write-Success "Package installation complete"
 }
 
@@ -454,6 +468,9 @@ function Connect-GH {
 
     gh auth status 2>&1 | Out-Null
     if ($LASTEXITCODE -eq 0) {
+        if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+            Write-Warn "git not found on PATH; gh extensions that shell out to git may fail. Install Git for Windows."
+        }
         Install-GHExtensions
         Write-Success "GitHub CLI extensions installed"
     } else {

--- a/setup.sh
+++ b/setup.sh
@@ -34,6 +34,14 @@ should_skip_installed() {
 # Mutable state
 failed_items=()
 
+# When true, the interactive sign-in checklist is skipped
+SKIP_SIGNIN="${SKIP_SIGNIN:-false}"
+for arg in "$@"; do
+    case "$arg" in
+        --skip-signin) SKIP_SIGNIN=true ;;
+    esac
+done
+
 # ----------------------------------------
 # Logging Helpers
 # ----------------------------------------
@@ -341,16 +349,148 @@ authenticate_gh() {
     fi
 }
 
-# Guides user through GitHub web authentication process using Chrome
-authenticate_github_web() {
-    log_info "Opening GitHub.com in Chrome..."
-    open -a "Google Chrome" https://github.com
+# Opens a URL in the platform's default browser
+open_url() {
+    local url="$1"
+    if [[ "$OSTYPE" == darwin* ]]; then
+        open "$url"
+    elif command -v xdg-open &> /dev/null; then
+        xdg-open "$url"
+    else
+        return 1
+    fi
+}
 
-    log_info "Please log in to GitHub.com in Chrome with the demo account"
-    log_info "Press Enter once you have logged in..."
+# Prints a numbered checklist header and waits for the user to confirm.
+# $1 = index, $2 = total, $3 = surface name, $4 = manual hint,
+# remaining args = command to launch the surface (run via "$@").
+signin_step() {
+    local index="$1" total="$2" name="$3" hint="$4"
+    shift 4
+
+    echo ""
+    echo -e "${BLUE}[$index/$total] $name${NC}"
+
+    if "$@"; then
+        [[ -n "$hint" ]] && log_info "$hint"
+    else
+        log_warn "Could not launch $name automatically."
+        [[ -n "$hint" ]] && log_warn "Manual step: $hint"
+    fi
+
+    log_info "Press Enter once you've signed in to $name (or to skip)..."
     read -r
+    log_success "$name - confirmed"
+}
 
-    log_success "GitHub web authentication confirmed"
+# Launch helpers for each surface (return non-zero on failure so signin_step
+# can fall back to the manual hint).
+launch_browser_signin() { open_url "https://github.com/login"; }
+
+launch_copilot_cli_signin() {
+    command -v copilot &> /dev/null || return 1
+    if [[ "$OSTYPE" == darwin* ]]; then
+        # Open the Copilot CLI in a new Terminal window so the user can run /login.
+        osascript -e 'tell application "Terminal" to activate' \
+                  -e 'tell application "Terminal" to do script "copilot"' &> /dev/null
+    else
+        # TODO: verify a reliable terminal launcher across Linux desktops.
+        if command -v x-terminal-emulator &> /dev/null; then
+            x-terminal-emulator -e copilot &> /dev/null &
+        else
+            return 1
+        fi
+    fi
+}
+
+launch_editor_signin() {
+    # $1 = editor command (code / code-insiders)
+    local cmd="$1"
+    command -v "$cmd" &> /dev/null || return 1
+    "$cmd" --command "github.copilot.signIn" &> /dev/null
+}
+
+launch_copilot_app_signin() {
+    if [[ "$OSTYPE" == darwin* ]]; then
+        open -a "GitHub Copilot"
+    else
+        # TODO: verify the Copilot desktop app launch target on Linux.
+        if command -v github-copilot &> /dev/null; then
+            github-copilot &> /dev/null &
+        else
+            return 1
+        fi
+    fi
+}
+
+# Guides the user through signing in to every GitHub surface, one at a time.
+# Order matters: the browser session is established first so the other tools
+# inherit the correct account.
+start_signin_checklist() {
+    if [[ "$SKIP_SIGNIN" == "true" ]]; then
+        log_info "Skipping sign-in checklist (--skip-signin was specified)."
+        return 0
+    fi
+
+    # Only run when both stdin and stdout are TTYs (matches prompt_for_inputs).
+    if [[ ! -t 0 ]] || [[ ! -t 1 ]]; then
+        log_info "Non-interactive session detected; skipping sign-in checklist."
+        return 0
+    fi
+
+    echo ""
+    echo -e "${BLUE}========================================${NC}"
+    echo -e "${BLUE}GitHub sign-in checklist${NC}"
+    echo -e "${BLUE}Sign in to each surface one at a time.${NC}"
+    echo -e "${BLUE}Order matters: the browser session is the source of truth others inherit.${NC}"
+    echo -e "${BLUE}========================================${NC}"
+
+    if [[ -n "${DEMO_GH_USER:-}" ]]; then
+        log_info "Expected demo account: $DEMO_GH_USER  (verify every surface signs in as this user)"
+    else
+        log_info "Tip: set DEMO_GH_USER to display the expected demo account here."
+    fi
+
+    local total=6
+
+    # Step 1: Web browser (establish the browser session first)
+    signin_step 1 "$total" "Web browser (github.com)" \
+        "Open https://github.com/login and sign in as the demo account." \
+        launch_browser_signin
+
+    # Step 2: GitHub CLI (skip if authenticate_gh already signed in)
+    if command -v gh &> /dev/null && gh auth status &> /dev/null; then
+        echo ""
+        echo -e "${BLUE}[2/$total] GitHub CLI (gh)${NC}"
+        log_success "GitHub CLI - already authenticated, skipping"
+    else
+        signin_step 2 "$total" "GitHub CLI (gh)" \
+            "Run 'gh auth login --web' and complete the device flow in the browser." \
+            gh auth login --web
+    fi
+
+    # Step 3: Copilot CLI (first-run device flow via /login)
+    signin_step 3 "$total" "Copilot CLI (copilot)" \
+        "In the Copilot CLI window, run the '/login' slash command to authenticate." \
+        launch_copilot_cli_signin
+
+    # Step 4: VS Code
+    signin_step 4 "$total" "VS Code" \
+        "If Copilot doesn't prompt, sign in via the Accounts menu (bottom-left)." \
+        launch_editor_signin code
+
+    # Step 5: VS Code Insiders
+    signin_step 5 "$total" "VS Code Insiders" \
+        "If Copilot doesn't prompt, sign in via the Accounts menu (bottom-left)." \
+        launch_editor_signin code-insiders
+
+    # Step 6: Copilot desktop app
+    signin_step 6 "$total" "Copilot app (desktop)" \
+        "Launch the GitHub Copilot app and sign in inside the app." \
+        launch_copilot_app_signin
+
+    echo ""
+    log_success "Sign-in checklist complete."
 }
 
 # Assists user in setting up Progressive Web Apps (PWAs)
@@ -763,9 +903,6 @@ configure_vlc
 # Launch post-install apps (e.g., Docker)
 launch_post_install_apps
 
-# Web authentication (after packages so Chrome is available)
-authenticate_github_web
-
 # Setup environments
 authenticate_gh
 clone_repos
@@ -773,6 +910,9 @@ install_pwas
 
 # Install extensions and configure themes
 configure_editors
+
+# Guided GitHub sign-in across all surfaces (browser first so others inherit the session)
+start_signin_checklist
 
 # Register MCP servers for Copilot CLI
 register_mcp_servers


### PR DESCRIPTION
## What & why

Provisioned demo machines need to sign in to the same GitHub account across several tools. Doing this by hand is error-prone, and most surfaces authorize **through the default browser session**, so the wrong browser identity silently poisons everything downstream.

This adds a guided, sequential sign-in checklist that launches each surface **one at a time, in a fixed order**, and waits for the user to confirm before moving on. The browser is first so every other tool inherits the correct account.

**Order:** web browser (github.com) → GitHub CLI → Copilot CLI → VS Code → VS Code Insiders → Copilot desktop app.

## Status

- ✅ **Windows (`setup.ps1`) is complete** and the primary deliverable.
- ✅ **macOS/Linux (`setup.sh`) parity is implemented**, with Linux Copilot CLI/app launches as clearly-marked best-effort `TODO`s (they can't be verified in CI).

## `setup.ps1` (Windows)

- New `-SkipSignIn` switch parameter.
- `Invoke-SignInStep` helper + `Start-SignInChecklist` function, using the existing `Write-Info/Success/Warn/Err` helpers and the existing Cyan banner style (no new `Write-Header`).
- Each step prints `[n/total] <Surface>`, attempts the launch in try/catch, falls back to `Write-Warn` + a manual hint if the tool is missing, then `Read-Host` to confirm, then `Write-Success`.
- **Native command failures don't throw in PowerShell**, so the `gh`/`code`/`code-insiders` launches explicitly check `$LASTEXITCODE` and `throw`, ensuring the manual-fallback path actually triggers.
- Skips step 2 when `gh auth status` already reports authenticated (avoids double-prompting after `Connect-GH`).
- Auto-skips the whole checklist on `-SkipSignIn` or non-interactive runs (`[Console]::IsInputRedirected`, matching the existing `Read-SetupInputs` convention).
- Prints `$Env:DEMO_GH_USER` at the top if set, as a visual checkpoint.
- Wired into Main Execution after `Initialize-Editors` (so editors/CLIs exist by then).

## `setup.sh` (macOS/Linux)

- New `--skip-signin` flag + `SKIP_SIGNIN` var.
- `start_signin_checklist` mirrors the six steps with OS-aware launchers: `open`/`xdg-open` for the browser, `gh auth login --web`, `code`/`code-insiders --command github.copilot.signIn`, and `open -a "GitHub Copilot"` for the desktop app on macOS.
- Auto-skips on `--skip-signin` or non-interactive (`[[ -t 0 ]] && [[ -t 1 ]]`).
- Replaces the old `authenticate_github_web` (Chrome) step — checklist step 1 supersedes it.
- Bash 3.2-safe (no bash-4 features), so it runs on stock macOS bash.

## Verified launch mechanisms (called out per request)

- **Copilot CLI login** is the **`/login` slash command** inside the interactive TUI — there is **no `copilot auth login`**. PS launches `copilot` in a persistent window so the user can run `/login`; bash opens it in a new Terminal on macOS.
- **Copilot desktop app (Windows):** found by checking preferred exe names (`GitHub Copilot.exe`, `GitHubCopilot.exe`, `Copilot.exe`) in the `%LOCALAPPDATA%\Programs\github-copilot` marker dirs, then a filtered recursive search, then a **`*GitHub*Copilot*.lnk`** Start Menu shortcut (narrowed so it can't match *Microsoft* Copilot), then a manual fallback warning.
- **Copilot desktop app (macOS):** `open -a "GitHub Copilot"` (the `github-copilot-app` cask installs `GitHub Copilot.app`).
- **VS Code / Insiders:** `--command github.copilot.signIn`, always paired with a manual "sign in via the Accounts menu" hint in case the command ID is unreliable.

## ⚠️ Discrepancy to flag

The task assumed winget id **`GitHub.Copilot`** installs the Copilot **desktop app**. Per current docs, `GitHub.Copilot` actually installs the **Copilot CLI**. The Windows **desktop** app is installed separately by the existing `Install-CopilotApp` (direct EXE download to `%LOCALAPPDATA%\Programs\github-copilot`), which is what the checklist's app step targets.

## Design decision: surface list kept inline (not `config.json`)

The launch logic is highly platform/tool-specific (call operators, `$LASTEXITCODE` handling, `osascript`, Start Menu lookups). Encoding that in `config.json` would push imperative behavior into data and add more risk than it removes, so the ordered steps live inline in each script. Easy to revisit if more surfaces are added.

## Follow-ups

- Linux Copilot CLI launcher (`x-terminal-emulator`) and Copilot desktop app launcher are best-effort and marked `TODO` — they need verification on a real Linux desktop.

## Validation

- `setup.ps1`: passes AST `[Parser]::ParseFile` under PowerShell 7.6.2; no new non-ASCII glyphs introduced (only pre-existing emoji/em-dashes), encoding preserved.
- `setup.sh`: passes `bash -n` and `shellcheck` (remaining shellcheck findings are all pre-existing lines, none in the new code).
- Interactive sign-in flows themselves can't run in CI; review focused on parse validity, correct command construction, and clean control flow.

## Update: install ordering + Copilot marker DRY

- **VS Enterprise install moved to the end** of Main Execution. `vs_enterprise.exe` runs with `--wait` (blocking), so running it early stalled everything. It now runs after the quick interactive steps so the user can finish the sign-in checklist first, then walk away while VS installs. Tail order: `Initialize-Editors → Register-MCPServers → Start-SignInChecklist → Install-VisualStudio → New-DemoLoader → Write-Summary`. Install logic unchanged; Windows-only.
- **DRY Copilot app markers:** extracted `Get-CopilotAppMarkerDir` (the three `%LOCALAPPDATA%\Programs\` dirs), reused by both `Install-CopilotApp` and the checklist's Copilot app step.

## Update: Git added as a prerequisite

`gh` configures `git_protocol` and several gh extensions (e.g. `github/gh-codeql`) shell out to git, which failed with `unable to find git executable in PATH` because Git was never installed.

- **config.json:** added `Git.Git` to the top of `windows.packages` and `git` to `mac.packages.formulas`.
- **setup.ps1:** after the post-install PATH refresh in `Install-Packages`, a defensive fallback prepends `C:\Program Files\Git\cmd` when git still isn't resolvable but `git.exe` exists there (visible via `Write-Info`/`Write-Warn`, no hard fail). `Connect-GH` now warns if git is missing before installing gh extensions but still attempts them.
- **setup.sh:** no code change needed — the formula loop installs `git` from config and brew is already on PATH (`brew shellenv`) before the gh extension step.
- Re-validated: `jq empty config.json`, `bash -n setup.sh`, and `setup.ps1` AST `ParseFile` all pass.