### PR TITLE
Add per-machine video subfolder prompt to demo loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ Azure DevOps organization name (leave blank to skip the Azure DevOps MCP server)
 
 **State file:** the cached value lives at `${COPILOT_HOME:-~/.copilot}/machine-setup-state.json` (Mac/Linux) or `%COPILOT_HOME%\machine-setup-state.json` / `%USERPROFILE%\.copilot\machine-setup-state.json` (Windows). Edit or delete this file to change the cached answer outside setup.
 
+### Demo video subfolder
+
+The demo loader opens VLC pointed at your `~/Videos` folder. If you copy the same full set of videos to every machine but organize them into subfolders (e.g. `~/Videos/booth-keynote`, `~/Videos/booth-security`), setup can point this machine's loader at just one of them. Setup prompts you for the subfolder once and caches the answer.
+
+**During setup:**
+
+```
+Video subfolder under ~/Videos to play (blank to play ~/Videos directly)
+> booth-keynote
+```
+
+- Enter a subfolder name to play only `~/Videos/<subfolder>`.
+- Leave it blank to play `~/Videos` directly (the default; identical to previous behavior).
+- On re-runs, the prompt shows your cached value; press Enter to keep it, type a new value to change it, or `-` to clear it back to the `~/Videos` root.
+- If `~/Videos` already contains subfolders, their names are listed in the prompt as a hint.
+
+This is a free-text prompt on purpose: the videos do not need to exist on disk when setup runs (you can drag them in later). If the chosen subfolder isn't present yet, setup warns but continues - just make sure the videos are in place before you run the demo loader.
+
+**Non-interactive runs** use the cached value, or the `~/Videos` root if none is cached. To set the subfolder without a prompt, export `VIDEO_SUBFOLDER=booth-keynote` (or `VIDEO_SUBFOLDER=` for the root) before running setup. The cached value lives in the same state file described above, under `inputs.video_subfolder`.
+
 ### Visual Studio (Windows)
 
 Visual Studio is installed via the official Microsoft bootstrapper (`vs_enterprise.exe`) — not via winget — because winget only publishes manifests for VS 2017/2019/2022. The script downloads the latest Visual Studio 2026 Enterprise bootstrapper from `https://aka.ms/vs/stable/vs_enterprise.exe` (per the [official command-line install docs](https://learn.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio)) and runs it with the configured workloads.

--- a/setup.ps1
+++ b/setup.ps1
@@ -119,11 +119,12 @@ function Get-SetupStatePath {
     return (Join-Path $copilotHome "machine-setup-state.json")
 }
 
-# Reads the setup state into $script:AdoOrgValue and $script:AdoOrgMode.
-# Tolerates missing or corrupt state.
+# Reads the setup state into $script:AdoOrgValue / $script:AdoOrgMode and
+# $script:VideoSubfolder. Tolerates missing or corrupt state.
 function Get-SetupState {
     $script:AdoOrgValue = ""
     $script:AdoOrgMode = ""
+    $script:VideoSubfolder = ""
 
     $statePath = Get-SetupStatePath
     if (-not (Test-Path $statePath)) { return }
@@ -135,15 +136,23 @@ function Get-SetupState {
         return
     }
 
-    if ($state.PSObject.Properties.Name -contains 'inputs' -and
-        $state.inputs.PSObject.Properties.Name -contains 'azure_devops_org') {
-        $entry = $state.inputs.azure_devops_org
-        if ($entry.PSObject.Properties.Name -contains 'value') { $script:AdoOrgValue = [string]$entry.value }
-        if ($entry.PSObject.Properties.Name -contains 'mode')  { $script:AdoOrgMode  = [string]$entry.mode  }
+    if ($state.PSObject.Properties.Name -contains 'inputs') {
+        if ($state.inputs.PSObject.Properties.Name -contains 'azure_devops_org') {
+            $entry = $state.inputs.azure_devops_org
+            if ($entry.PSObject.Properties.Name -contains 'value') { $script:AdoOrgValue = [string]$entry.value }
+            if ($entry.PSObject.Properties.Name -contains 'mode')  { $script:AdoOrgMode  = [string]$entry.mode  }
+        }
+        if ($state.inputs.PSObject.Properties.Name -contains 'video_subfolder') {
+            $videoEntry = $state.inputs.video_subfolder
+            if ($videoEntry.PSObject.Properties.Name -contains 'value') {
+                # Re-sanitize cached value so a hand-edited state file can't inject
+                $script:VideoSubfolder = ConvertTo-SafeVideoSubfolder ([string]$videoEntry.value)
+            }
+        }
     }
 }
 
-# Atomically writes the current $script:AdoOrg* values to the state file.
+# Atomically writes the current per-machine inputs to the state file.
 function Save-SetupState {
     $statePath = Get-SetupStatePath
     $copilotHome = Split-Path -Parent $statePath
@@ -166,6 +175,9 @@ function Save-SetupState {
     $entry = [PSCustomObject]@{ value = $script:AdoOrgValue; mode = $script:AdoOrgMode }
     $existing.inputs | Add-Member -NotePropertyName azure_devops_org -NotePropertyValue $entry -Force
 
+    $videoEntry = [PSCustomObject]@{ value = $script:VideoSubfolder }
+    $existing.inputs | Add-Member -NotePropertyName video_subfolder -NotePropertyValue $videoEntry -Force
+
     $tmp = "$statePath.tmp"
     try {
         $existing | ConvertTo-Json -Depth 10 | Out-File -FilePath $tmp -Encoding UTF8 -Force
@@ -179,10 +191,15 @@ function Save-SetupState {
 }
 
 # Prompts (when TTY) for per-machine inputs.
-# Precedence: ADO_ORG env var > interactive prompt > cached value > skip.
 function Read-SetupInputs {
     Get-SetupState
+    Read-AdoOrgInput
+    Read-VideoSubfolderInput
+}
 
+# Prompts for the Azure DevOps organization.
+# Precedence: ADO_ORG env var > interactive prompt > cached value > skip.
+function Read-AdoOrgInput {
     # 1. Env var override (explicit empty = skip)
     if (Test-Path env:ADO_ORG) {
         $envVal = [string]$env:ADO_ORG
@@ -261,6 +278,132 @@ function Read-SetupInputs {
         Write-Info "Non-interactive run with no cached value; Azure DevOps MCP server will be skipped"
         $script:AdoOrgValue = ""
         $script:AdoOrgMode = "skip"
+    }
+}
+
+# Sanitizes a user-entered video subfolder. Returns "" (use ~/Videos root) for
+# empty or unsafe input (path traversal, absolute/rooted paths, or quote chars).
+function ConvertTo-SafeVideoSubfolder {
+    param([string]$Value)
+    if ($null -eq $Value) { return "" }
+    $v = $Value.Trim()
+    if ([string]::IsNullOrEmpty($v)) { return "" }
+    # Normalize forward slashes to backslashes for uniform handling
+    $v = $v -replace '/', '\'
+    # Reject path traversal, drive-rooted (C:), UNC (\\), shell/PS metacharacters
+    # ($ ` " expand inside the double-quoted loader string), or control chars
+    if ($v -match '\.\.' -or $v -match '^[A-Za-z]:' -or $v.StartsWith('\\') -or
+        $v.Contains('"') -or $v.Contains('$') -or $v.Contains('`') -or $v -match '[\x00-\x1f]') {
+        Write-Warn "Video subfolder '$Value' looks unsafe (path traversal, absolute path, or special characters); using ~/Videos root"
+        return ""
+    }
+    # Strip leading/trailing backslashes and collapse repeated separators
+    $v = $v.Trim('\')
+    $v = $v -replace '\\+', '\'
+    return $v
+}
+
+# Returns a comma-separated list of immediate subdirectory names under $VideosRoot.
+# Hint only; never required and never blocks.
+function Get-VideoSubfolderHint {
+    param([string]$VideosRoot)
+    try {
+        if (-not (Test-Path $VideosRoot)) { return "" }
+        $dirs = Get-ChildItem -Path $VideosRoot -Directory -ErrorAction Stop | Select-Object -ExpandProperty Name
+        if ($dirs) { return ($dirs -join ', ') }
+    } catch {
+        # Listing is a convenience only; ignore any failure
+    }
+    return ""
+}
+
+# Warns (but never fails) when the chosen subfolder is not yet present on disk.
+function Test-VideoSubfolderPresent {
+    param([string]$VideosRoot)
+    if ([string]::IsNullOrEmpty($script:VideoSubfolder)) { return }
+    $target = Join-Path $VideosRoot $script:VideoSubfolder
+    if (-not (Test-Path $target)) {
+        Write-Warn "Videos subfolder '$($script:VideoSubfolder)' not found yet under ~/Videos; make sure the videos are copied there before running the demo loader."
+    }
+}
+
+# Prompts for the per-machine video subfolder under ~/Videos.
+# Precedence: VIDEO_SUBFOLDER env var > interactive prompt > cached value > "" (root).
+function Read-VideoSubfolderInput {
+    $videosRoot = Join-Path $env:USERPROFILE "Videos"
+
+    # 1. Env var override
+    if (Test-Path env:VIDEO_SUBFOLDER) {
+        $script:VideoSubfolder = ConvertTo-SafeVideoSubfolder ([string]$env:VIDEO_SUBFOLDER)
+        if ([string]::IsNullOrEmpty($script:VideoSubfolder)) {
+            Write-Info "VIDEO_SUBFOLDER is empty; demo loader will play ~/Videos directly"
+        } else {
+            Write-Info "Using video subfolder from VIDEO_SUBFOLDER env var: $($script:VideoSubfolder)"
+        }
+        Test-VideoSubfolderPresent $videosRoot
+        Save-SetupState
+        return
+    }
+
+    # 2. Interactive prompt (only when stdin isn't redirected)
+    $interactive = $true
+    try {
+        if ([Console]::IsInputRedirected) { $interactive = $false }
+    } catch {
+        # Some hosts don't expose this; fall through to try Read-Host
+    }
+
+    if ($interactive) {
+        if (-not [string]::IsNullOrEmpty($script:VideoSubfolder)) {
+            $hint = "[current: $($script:VideoSubfolder); Enter to keep, '-' to clear to root]"
+        } else {
+            $hint = "(blank to play ~/Videos directly)"
+        }
+        $available = Get-VideoSubfolderHint $videosRoot
+        if (-not [string]::IsNullOrEmpty($available)) {
+            $hint = "$hint (available: $available)"
+        }
+
+        $answer = $null
+        try {
+            $answer = Read-Host "Video subfolder under ~/Videos to play $hint"
+        } catch {
+            Write-Warn "Could not prompt for video subfolder; demo loader will play ~/Videos"
+            $script:VideoSubfolder = ""
+            Save-SetupState
+            return
+        }
+
+        $trimmed = if ($null -eq $answer) { "" } else { $answer.Trim() }
+
+        if ([string]::IsNullOrEmpty($trimmed)) {
+            if (-not [string]::IsNullOrEmpty($script:VideoSubfolder)) {
+                Write-Info "Keeping cached video subfolder: $($script:VideoSubfolder)"
+            } else {
+                $script:VideoSubfolder = ""
+                Write-Info "Demo loader will play ~/Videos directly"
+            }
+        } elseif ($trimmed -eq '-') {
+            $script:VideoSubfolder = ""
+            Write-Info "Cleared video subfolder; demo loader will play ~/Videos directly"
+        } else {
+            $script:VideoSubfolder = ConvertTo-SafeVideoSubfolder $trimmed
+            if ([string]::IsNullOrEmpty($script:VideoSubfolder)) {
+                Write-Info "Demo loader will play ~/Videos directly"
+            } else {
+                Write-Success "Video subfolder set to: $($script:VideoSubfolder)"
+            }
+        }
+        Test-VideoSubfolderPresent $videosRoot
+        Save-SetupState
+        return
+    }
+
+    # 3. Non-interactive: fall back to cached value if present
+    if (-not [string]::IsNullOrEmpty($script:VideoSubfolder)) {
+        Write-Info "Non-interactive run; using cached video subfolder: $($script:VideoSubfolder)"
+    } else {
+        Write-Info "Non-interactive run; demo loader will play ~/Videos directly"
     }
 }
 
@@ -984,7 +1127,11 @@ function New-DemoLoader {
 
     # Add VLC
     $lines += "# Open VLC"
-    $lines += 'Start-Process "vlc" -ArgumentList "$env:USERPROFILE\Videos"'
+    if (-not [string]::IsNullOrEmpty($script:VideoSubfolder)) {
+        $lines += 'Start-Process "vlc" -ArgumentList "$env:USERPROFILE\Videos\' + $script:VideoSubfolder + '"'
+    } else {
+        $lines += 'Start-Process "vlc" -ArgumentList "$env:USERPROFILE\Videos"'
+    }
     $lines += ""
     $lines += "Write-Host 'Demo environment loaded!' -ForegroundColor Green"
 

--- a/setup.sh
+++ b/setup.sh
@@ -571,6 +571,7 @@ setup_state_path() {
 load_setup_state() {
     ADO_ORG_VALUE=""
     ADO_ORG_MODE=""
+    VIDEO_SUBFOLDER_VALUE=""
 
     local state_path
     state_path=$(setup_state_path)
@@ -583,6 +584,8 @@ load_setup_state() {
 
     ADO_ORG_VALUE=$(jq -r '.inputs.azure_devops_org.value // ""' "$state_path")
     ADO_ORG_MODE=$(jq -r '.inputs.azure_devops_org.mode // ""' "$state_path")
+    # Re-sanitize cached value so a hand-edited state file can't inject
+    VIDEO_SUBFOLDER_VALUE=$(sanitize_video_subfolder "$(jq -r '.inputs.video_subfolder.value // ""' "$state_path")")
 }
 
 # Atomically writes the current ADO_ORG_VALUE / ADO_ORG_MODE to the state file.
@@ -601,7 +604,8 @@ save_setup_state() {
     updated=$(echo "$existing" | jq \
         --arg value "$ADO_ORG_VALUE" \
         --arg mode "$ADO_ORG_MODE" \
-        '.inputs //= {} | .inputs.azure_devops_org = {value: $value, mode: $mode}')
+        --arg vsub "$VIDEO_SUBFOLDER_VALUE" \
+        '.inputs //= {} | .inputs.azure_devops_org = {value: $value, mode: $mode} | .inputs.video_subfolder = {value: $vsub}')
 
     local tmp="${state_path}.tmp.$$"
     printf '%s\n' "$updated" > "$tmp" || { log_warn "Failed to write setup state"; rm -f "$tmp"; return 0; }
@@ -614,7 +618,14 @@ save_setup_state() {
     chmod 600 "$state_path" 2>/dev/null || true
 }
 
-# Prompts (when TTY) for inputs that vary per machine. Sets ADO_ORG_VALUE
+# Prompts (when TTY) for inputs that vary per machine.
+prompt_for_inputs() {
+    load_setup_state
+    prompt_for_ado_org
+    prompt_for_video_subfolder
+}
+
+# Prompts (when TTY) for the Azure DevOps org. Sets ADO_ORG_VALUE
 # and ADO_ORG_MODE ("configured", "skip", or "" = not answered).
 #
 # Precedence:
@@ -622,9 +633,7 @@ save_setup_state() {
 #   2. Interactive prompt with cached value as default
 #   3. Cached value (when non-interactive)
 #   4. Skip
-prompt_for_inputs() {
-    load_setup_state
-
+prompt_for_ado_org() {
     # 1. Env var override (always wins; explicit empty = skip)
     if [[ -n "${ADO_ORG+x}" ]]; then
         local trimmed
@@ -694,6 +703,134 @@ prompt_for_inputs() {
         log_info "Non-interactive run with no cached value; Azure DevOps MCP server will be skipped"
         ADO_ORG_VALUE=""
         ADO_ORG_MODE="skip"
+    fi
+}
+
+# Sanitizes a video subfolder value. Echoes a safe relative subfolder, or "" for
+# empty/unsafe input (path traversal, absolute paths, or quote chars). Any
+# warning is sent to stderr so it does not pollute the captured value.
+sanitize_video_subfolder() {
+    local raw="$1"
+    local v
+    v="${raw#"${raw%%[![:space:]]*}"}"
+    v="${v%"${v##*[![:space:]]}"}"
+    [[ -z "$v" ]] && { echo ""; return; }
+    # Normalize backslashes to forward slashes (loader uses POSIX paths)
+    v="${v//\\//}"
+    # Reject path traversal, drive-rooted (C:), UNC-style (//), shell metacharacters
+    # ($ ` " expand inside the double-quoted loader string), or control chars
+    if [[ "$v" == *".."* ]] || [[ "$v" =~ ^[A-Za-z]: ]] || [[ "$v" == //* ]] \
+        || [[ "$v" == *'"'* ]] || [[ "$v" == *'$'* ]] || [[ "$v" == *'`'* ]] \
+        || [[ "$v" == *[[:cntrl:]]* ]]; then
+        log_warn "Video subfolder '$raw' looks unsafe (path traversal, absolute path, or special characters); using ~/Videos root" >&2
+        echo ""
+        return
+    fi
+    # Strip leading/trailing slashes and collapse duplicate separators
+    v="${v#/}"
+    v="${v%/}"
+    while [[ "$v" == *"//"* ]]; do v="${v//\/\//\/}"; done
+    echo "$v"
+}
+
+# Lists immediate subdirectory names under the given dir as a comma-separated
+# string. Hint only; never required and never blocks.
+list_video_subfolders() {
+    local root="$1"
+    [[ -d "$root" ]] || { echo ""; return; }
+    local out="" d name
+    for d in "$root"/*/; do
+        [[ -d "$d" ]] || continue
+        d="${d%/}"
+        name="${d##*/}"
+        if [[ -z "$out" ]]; then out="$name"; else out="$out, $name"; fi
+    done
+    echo "$out"
+}
+
+# Warns (but never fails) when the chosen subfolder is not yet present on disk.
+warn_if_video_subfolder_missing() {
+    local root="$1"
+    [[ -n "$VIDEO_SUBFOLDER_VALUE" ]] || return 0
+    if [[ ! -d "$root/$VIDEO_SUBFOLDER_VALUE" ]]; then
+        log_warn "Videos subfolder '$VIDEO_SUBFOLDER_VALUE' not found yet under ~/Videos; make sure the videos are copied there before running the demo loader."
+    fi
+}
+
+# Prompts (when TTY) for the per-machine video subfolder under ~/Videos.
+# Sets VIDEO_SUBFOLDER_VALUE ("" = play ~/Videos root).
+#
+# Precedence:
+#   1. VIDEO_SUBFOLDER env var (if set; empty/unsafe = root)
+#   2. Interactive prompt with cached value as default
+#   3. Cached value (when non-interactive)
+#   4. Root ("")
+prompt_for_video_subfolder() {
+    local videos_root="$HOME/Videos"
+
+    # 1. Env var override
+    if [[ -n "${VIDEO_SUBFOLDER+x}" ]]; then
+        VIDEO_SUBFOLDER_VALUE=$(sanitize_video_subfolder "$VIDEO_SUBFOLDER")
+        if [[ -z "$VIDEO_SUBFOLDER_VALUE" ]]; then
+            log_info "VIDEO_SUBFOLDER is empty; demo loader will play ~/Videos directly"
+        else
+            log_info "Using video subfolder from VIDEO_SUBFOLDER env var: $VIDEO_SUBFOLDER_VALUE"
+        fi
+        warn_if_video_subfolder_missing "$videos_root"
+        save_setup_state
+        return 0
+    fi
+
+    # 2. Interactive prompt (only when both stdin and stdout are TTYs)
+    if [[ -t 0 ]] && [[ -t 1 ]]; then
+        local hint
+        if [[ -n "$VIDEO_SUBFOLDER_VALUE" ]]; then
+            hint="[current: $VIDEO_SUBFOLDER_VALUE; Enter to keep, '-' to clear to root]"
+        else
+            hint="(blank to play ~/Videos directly)"
+        fi
+        local available
+        available=$(list_video_subfolders "$videos_root")
+        if [[ -n "$available" ]]; then
+            hint="$hint (available: $available)"
+        fi
+
+        local answer
+        printf 'Video subfolder under ~/Videos to play %s\n> ' "$hint" >&2
+        IFS= read -r answer || answer=""
+
+        local trimmed
+        trimmed="${answer#"${answer%%[![:space:]]*}"}"
+        trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+
+        if [[ -z "$trimmed" ]]; then
+            if [[ -n "$VIDEO_SUBFOLDER_VALUE" ]]; then
+                log_info "Keeping cached video subfolder: $VIDEO_SUBFOLDER_VALUE"
+            else
+                VIDEO_SUBFOLDER_VALUE=""
+                log_info "Demo loader will play ~/Videos directly"
+            fi
+        elif [[ "$trimmed" == "-" ]]; then
+            VIDEO_SUBFOLDER_VALUE=""
+            log_info "Cleared video subfolder; demo loader will play ~/Videos directly"
+        else
+            VIDEO_SUBFOLDER_VALUE=$(sanitize_video_subfolder "$trimmed")
+            if [[ -z "$VIDEO_SUBFOLDER_VALUE" ]]; then
+                log_info "Demo loader will play ~/Videos directly"
+            else
+                log_success "Video subfolder set to: $VIDEO_SUBFOLDER_VALUE"
+            fi
+        fi
+        warn_if_video_subfolder_missing "$videos_root"
+        save_setup_state
+        return 0
+    fi
+
+    # 3. Non-interactive: fall back to cached value if present
+    if [[ -n "$VIDEO_SUBFOLDER_VALUE" ]]; then
+        log_info "Non-interactive run; using cached video subfolder: $VIDEO_SUBFOLDER_VALUE"
+    else
+        log_info "Non-interactive run; demo loader will play ~/Videos directly"
     fi
 }
 
@@ -846,8 +983,15 @@ open -a "Visual Studio Code"
 open -a "Visual Studio Code - Insiders"
 
 # Open VLC pointing to Videos folder
-open -a VLC "$HOME/Videos"
 EOF
+
+    # Emit the VLC line outside the quoted heredoc so the chosen subfolder is
+    # injected now while $HOME stays literal (resolved at loader runtime).
+    if [[ -n "$VIDEO_SUBFOLDER_VALUE" ]]; then
+        printf 'open -a VLC "$HOME/Videos/%s"\n' "$VIDEO_SUBFOLDER_VALUE" >> "$demo_script"
+    else
+        printf 'open -a VLC "$HOME/Videos"\n' >> "$demo_script"
+    fi
 
     chmod +x "$demo_script"
     log_success "Created demo loader script at $demo_script"


### PR DESCRIPTION
## What & why

The setup scripts generate a `load-demos` script on the Desktop that opens VLC pointed at `~/Videos`. The user copies the **same** full set of videos to every machine, organized into subfolders (e.g. `~/Videos/booth-keynote`, `~/Videos/booth-security`), but each machine should play only **one** subfolder. This adds a per-machine "video subfolder" input that bakes `~/Videos/<subfolder>` into the generated demo loader.

Implemented in **both** `setup.ps1` (Windows, primary) and `setup.sh` (macOS/Linux, parity), plus README docs.

## How the prompt works

- **Free text, not a validated menu.** This is deliberate: the videos may **not** be on disk when setup runs (they're drag/dropped in parallel or afterwards). So the prompt never hard-gates on folder existence. If the chosen folder is absent, setup **warns but continues** - the only ordering requirement is that the videos exist before the loader is later run.
- **Precedence:** `VIDEO_SUBFOLDER` env var > interactive prompt > cached value > `""` (root).
- **Semantics** (mirrors the existing Azure DevOps org prompt): blank + cached value = keep cached; blank + no cache = root; `-` = clear to root.
- **Non-blocking hint:** when `~/Videos` already has subdirectories, their names are listed in the prompt as `(available: a, b, c)`. Purely a convenience - never required.
- **Caching:** stored in `~/.copilot/machine-setup-state.json` under `inputs.video_subfolder`, alongside the existing `inputs.azure_devops_org`. State save is read-modify-write so the two inputs never clobber each other.

## Demo loader change

When a subfolder is set, the loader targets `~/Videos/<subfolder>`, else the current `~/Videos` (default/empty behavior is byte-for-byte identical to today). The loader keeps `$env:USERPROFILE` / `$HOME` **unexpanded** so they resolve at loader runtime. On bash the VLC line is emitted outside the quoted heredoc so the subfolder is injected while `$HOME` stays literal.

## Safety

Because the generated loader strings are interpreted at runtime, the sanitizer rejects path traversal (`..`), absolute/rooted paths (drive letters, UNC), and shell/PowerShell metacharacters (`"`, `$`, backtick) and control chars - falling back to the `~/Videos` root with a warning. Cached values are re-sanitized on load so a hand-edited state file can't inject.

## Validation

- `pwsh` `Parser::ParseFile` on `setup.ps1`: **0 errors**; no new non-ASCII characters added (PS 5.1/7 safe).
- Focused test: generated VLC line is well-formed and parses for `""`, `booth-keynote`, and nested values.
- Sanitizer unit tests (both languages): traversal/absolute/drive/UNC/quote/`$`/backtick all rejected to root; leading/trailing slashes stripped.
- State no-clobber integration tests (both languages): ADO + video persist across sequential saves.
- `bash -n setup.sh` and `shellcheck` (no new warnings); `jq empty config.json` (unchanged - no config change needed).