### PR TITLE
Add Neovim and JetBrains IDEs with comment-out convention and checklist steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ Because `config.json` is JSON and can't carry real comments, packages are enable
 
 This applies to `windows.packages`, `mac.packages.casks`, and `mac.packages.formulas`. For example, a core set of JetBrains IDEs (IntelliJ IDEA Ultimate, PyCharm Professional, Rider, WebStorm) ships active, while extras (GoLand, CLion, PhpStorm, RubyMine, DataGrip, RustRover) ship commented out - uncomment the ones you want. Out of the box, the active IDEs install and the commented ones don't.
 
+### Choosing whether to install Neovim and JetBrains IDEs
+
+Both setup scripts ask two quick yes/no questions early in the run:
+
+- `Install Neovim (and auto-configure its GitHub Copilot plugin)?`
+- `Install JetBrains IDEs (IntelliJ IDEA, PyCharm, Rider, WebStorm)?`
+
+Answering no skips the relevant packages, skips the Neovim Copilot plugin setup, and omits the matching sign-in checklist steps. Pressing Enter accepts the default (yes). These choices apply to the current run only and are never saved.
+
+**Non-interactive runs** (CI, piped input, etc.) skip the prompts and default to installing both groups, so existing unattended behavior is unchanged. To control them without a prompt, set the `INSTALL_NEOVIM` and/or `INSTALL_JETBRAINS` environment variables to a truthy (`1`, `true`, `yes`, `y`, `on`) or falsy (`0`, `false`, `no`, `n`, `off`) value before running setup - for example, `INSTALL_JETBRAINS=no` to skip the JetBrains IDEs. The `# ` comment-out convention above still applies on top of these choices, so you can disable individual IDEs while keeping the rest.
+
 ### Neovim + GitHub Copilot
 
 Neovim is installed alongside the editors, and its GitHub Copilot plugin (`github/copilot.vim`) is cloned automatically into Neovim's native package path (`%LOCALAPPDATA%\nvim-data\site\pack\github\start` on Windows, `${XDG_DATA_HOME:-~/.local/share}/nvim/site/pack/github/start` on macOS/Linux). The plugin requires a Node.js runtime, which both scripts now install (`OpenJS.NodeJS.LTS` on Windows, the `node` formula on macOS). Authentication is handled interactively by the sign-in checklist (below), not at install time.
@@ -35,8 +46,8 @@ Neovim is installed alongside the editors, and its GitHub Copilot plugin (`githu
 
 The interactive sign-in checklist walks you through signing in to each GitHub surface one at a time. It now also covers Neovim and each active JetBrains IDE:
 
-- **Neovim** (only shown if `nvim` is installed): run `:Copilot setup` inside Neovim. If you already signed in to the Copilot CLI earlier in the checklist, Neovim *may* already be signed in via the shared Copilot token (`%LOCALAPPDATA%\github-copilot` on Windows, `~/.config/github-copilot` on macOS/Linux) - this isn't guaranteed, so confirm inside the editor.
-- **JetBrains IDEs** (one step per active IDE, derived from `config.json` - commenting an IDE out also removes its step): open the IDE, install the GitHub Copilot plugin (Settings/Preferences > Plugins > Marketplace > search "GitHub Copilot"), then sign in to Copilot inside the IDE. JetBrains generally requires its own in-IDE sign-in.
+- **Neovim** (only shown if you chose to install Neovim and `nvim` is on `PATH`): run `:Copilot setup` inside Neovim. If you already signed in to the Copilot CLI earlier in the checklist, Neovim *may* already be signed in via the shared Copilot token (`%LOCALAPPDATA%\github-copilot` on Windows, `~/.config/github-copilot` on macOS/Linux) - this isn't guaranteed, so confirm inside the editor.
+- **JetBrains IDEs** (one step per active IDE, shown only if you chose to install them; derived from `config.json` - commenting an IDE out also removes its step): open the IDE, install the GitHub Copilot plugin (Settings/Preferences > Plugins > Marketplace > search "GitHub Copilot"), then sign in to Copilot inside the IDE. JetBrains generally requires its own in-IDE sign-in.
 
 ## Setup Instructions
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This repository contains setup scripts for configuring booth machines. The scrip
 ## Features
 
 - Installs and configures Visual Studio Code and Visual Studio Code Insiders.
+- Installs Neovim and automatically sets up the official [GitHub Copilot plugin](https://github.com/github/copilot.vim) (`copilot.vim`).
+- Installs a core set of JetBrains IDEs (IntelliJ IDEA Ultimate, PyCharm Professional, Rider, WebStorm), with additional IDEs available by uncommenting them in `config.json`.
 - Installs GitHub CLI and a suite of GitHub CLI extensions.
 - Installs the GitHub Copilot CLI (`copilot`).
 - Installs the GitHub Copilot desktop app (via the [`github-copilot-app`](https://formulae.brew.sh/cask/github-copilot-app) Homebrew cask on macOS; direct download from the [`github/app`](https://github.com/github/app) releases on Windows).
@@ -18,6 +20,23 @@ This repository contains setup scripts for configuring booth machines. The scrip
 ## Configuration
 
 The configuration for the setup scripts is stored in the `config.json` file. You can customize the settings by modifying this file.
+
+### Enabling and disabling packages
+
+Because `config.json` is JSON and can't carry real comments, packages are enabled/disabled with a `# ` prefix convention: **any package entry whose value starts with `# ` is treated as disabled and skipped** by both setup scripts. To disable a package, prefix its id with `# `; to enable a commented-out one, remove the prefix.
+
+This applies to `windows.packages`, `mac.packages.casks`, and `mac.packages.formulas`. For example, a core set of JetBrains IDEs (IntelliJ IDEA Ultimate, PyCharm Professional, Rider, WebStorm) ships active, while extras (GoLand, CLion, PhpStorm, RubyMine, DataGrip, RustRover) ship commented out - uncomment the ones you want. Out of the box, the active IDEs install and the commented ones don't.
+
+### Neovim + GitHub Copilot
+
+Neovim is installed alongside the editors, and its GitHub Copilot plugin (`github/copilot.vim`) is cloned automatically into Neovim's native package path (`%LOCALAPPDATA%\nvim-data\site\pack\github\start` on Windows, `${XDG_DATA_HOME:-~/.local/share}/nvim/site/pack/github/start` on macOS/Linux). The plugin requires a Node.js runtime, which both scripts now install (`OpenJS.NodeJS.LTS` on Windows, the `node` formula on macOS). Authentication is handled interactively by the sign-in checklist (below), not at install time.
+
+### Sign-in checklist
+
+The interactive sign-in checklist walks you through signing in to each GitHub surface one at a time. It now also covers Neovim and each active JetBrains IDE:
+
+- **Neovim** (only shown if `nvim` is installed): run `:Copilot setup` inside Neovim. If you already signed in to the Copilot CLI earlier in the checklist, Neovim *may* already be signed in via the shared Copilot token (`%LOCALAPPDATA%\github-copilot` on Windows, `~/.config/github-copilot` on macOS/Linux) - this isn't guaranteed, so confirm inside the editor.
+- **JetBrains IDEs** (one step per active IDE, derived from `config.json` - commenting an IDE out also removes its step): open the IDE, install the GitHub Copilot plugin (Settings/Preferences > Plugins > Marketplace > search "GitHub Copilot"), then sign in to Copilot inside the IDE. JetBrains generally requires its own in-IDE sign-in.
 
 ## Setup Instructions
 

--- a/config.json
+++ b/config.json
@@ -97,13 +97,26 @@
         "copilot-cli",
         "google-chrome",
         "github",
-        "github-copilot-app"
+        "github-copilot-app",
+        "# JetBrains IDEs: prefix any entry with '# ' to disable it",
+        "intellij-idea",
+        "pycharm",
+        "rider",
+        "webstorm",
+        "# goland",
+        "# clion",
+        "# phpstorm",
+        "# rubymine",
+        "# datagrip",
+        "# rustrover"
       ],
       "formulas": [
         "git",
         "gh",
         "python@3.14",
-        "nvm"
+        "nvm",
+        "node",
+        "neovim"
       ]
     },
     "editors": [
@@ -124,6 +137,7 @@
   },
   "windows": {
     "packages": [
+      "# To disable any package below, prefix its id with '# '. Lines starting with # are skipped.",
       "Git.Git",
       "Microsoft.VisualStudioCode",
       "Microsoft.VisualStudioCode.Insiders",
@@ -133,7 +147,19 @@
       "GitHub.Copilot",
       "Google.Chrome",
       "GitHub.GitHubDesktop",
-      "OpenJS.NodeJS.LTS"
+      "OpenJS.NodeJS.LTS",
+      "# Neovim + JetBrains IDEs (prefix any id with '# ' to disable it)",
+      "Neovim.Neovim",
+      "JetBrains.IntelliJIDEA.Ultimate",
+      "JetBrains.PyCharm.Professional",
+      "JetBrains.Rider",
+      "JetBrains.WebStorm",
+      "# JetBrains.GoLand",
+      "# JetBrains.CLion",
+      "# JetBrains.PhpStorm",
+      "# JetBrains.RubyMine",
+      "# JetBrains.DataGrip",
+      "# JetBrains.RustRover"
     ],
     "visual_studio": {
       "edition": "Enterprise",

--- a/setup.ps1
+++ b/setup.ps1
@@ -33,6 +33,17 @@ $script:ForceReinstall = $env:FORCE_REINSTALL -eq "true"
 
 function Test-ShouldSkipInstalled { return -not $script:ForceReinstall }
 
+# Returns $true if a package entry is "active" (should be installed). An entry is
+# considered disabled (returns $false) when it is null, whitespace-only, or its
+# trimmed value begins with '#'. This lets config.json (which can't have real JSON
+# comments) document and disable packages by prefixing their id with '# '.
+function Test-ActivePackageEntry {
+    param([string]$Entry)
+    if ([string]::IsNullOrWhiteSpace($Entry)) { return $false }
+    if ($Entry.TrimStart().StartsWith("#")) { return $false }
+    return $true
+}
+
 # ----------------------------------------
 # Logging Helpers
 # ----------------------------------------
@@ -418,6 +429,12 @@ function Install-Packages {
     Write-Info "Installing packages via winget..."
 
     foreach ($package in $config.windows.packages) {
+        # Skip disabled/documentation entries (those prefixed with '# ' in config.json).
+        if (-not (Test-ActivePackageEntry $package)) {
+            Write-Info "Skipping disabled package: $package"
+            continue
+        }
+
         # Chrome may be installed outside of winget (MDM, OEM, manual download, etc.)
         # so we check the filesystem to avoid install conflicts
         if ((Test-ShouldSkipInstalled) -and $package -eq "Google.Chrome" -and (Test-Path "${env:ProgramFiles}\Google\Chrome\Application\chrome.exe")) {
@@ -448,6 +465,70 @@ function Install-Packages {
     }
 
     Write-Success "Package installation complete"
+}
+
+function Install-NeovimCopilot {
+    # Installs the official github/copilot.vim plugin into Neovim's native package
+    # start path so it loads automatically. Idempotent and never fatal.
+    Write-Info "Setting up Neovim GitHub Copilot plugin..."
+
+    if (-not (Get-Command nvim -ErrorAction SilentlyContinue)) {
+        Write-Info "Neovim (nvim) not found on PATH; skipping Copilot plugin setup."
+        return
+    }
+
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        Write-Warn "git not found on PATH; cannot install Neovim Copilot plugin. Skipping."
+        return
+    }
+
+    $target = Join-Path $env:LOCALAPPDATA "nvim-data\site\pack\github\start\copilot.vim"
+    $parent = Split-Path -Parent $target
+
+    if (-not (Test-Path $parent)) {
+        try {
+            New-Item -Path $parent -ItemType Directory -Force | Out-Null
+        } catch {
+            Write-Warn "Could not create Neovim plugin directory '$parent': $_"
+            $script:failedItems += "Neovim Copilot plugin (mkdir)"
+            return
+        }
+    }
+
+    if (-not (Test-Path $target)) {
+        Invoke-SafeInstall -Description "Neovim Copilot plugin (clone)" -Action {
+            git clone --depth 1 https://github.com/github/copilot.vim $target 2>&1
+        }
+        if (-not (Test-Path (Join-Path $target ".git"))) {
+            Write-Warn "Neovim Copilot plugin clone did not complete; skipping. You can retry later."
+            return
+        }
+    }
+    elseif (Test-Path (Join-Path $target ".git")) {
+        if (Test-ShouldSkipInstalled) {
+            # Already a repo and we're not forcing; refresh best-effort.
+            try {
+                git -C $target pull --ff-only 2>&1 | Out-Null
+                if ($LASTEXITCODE -ne 0) { Write-Warn "Could not update Neovim Copilot plugin (git pull failed); continuing." }
+            } catch {
+                Write-Warn "Could not update Neovim Copilot plugin: $_"
+            }
+        } else {
+            Invoke-SafeInstall -Description "Neovim Copilot plugin (pull)" -Action {
+                git -C $target pull --ff-only 2>&1
+            }
+        }
+    }
+    else {
+        Write-Warn "Neovim Copilot plugin path exists but is not a git repo; leaving it untouched: $target"
+        return
+    }
+
+    if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+        Write-Warn "Node.js (node) not found on PATH; Neovim Copilot may not work until Node is available."
+    }
+
+    Write-Success "Neovim GitHub Copilot plugin ready"
 }
 
 function Start-PostInstallApps {
@@ -631,6 +712,43 @@ function Get-CopilotAppMarkerDir {
     )
 }
 
+function Get-JetBrainsDisplayName {
+    param([string]$Id)
+    # Map winget JetBrains ids (with the 'JetBrains.' prefix stripped) to friendly
+    # display names. Unknown ids fall back to the raw id so we never crash.
+    $map = @{
+        'IntelliJIDEA.Ultimate'  = 'IntelliJ IDEA Ultimate'
+        'IntelliJIDEA.Community' = 'IntelliJ IDEA Community'
+        'PyCharm.Professional'   = 'PyCharm Professional'
+        'PyCharm.Community'      = 'PyCharm Community'
+        'Rider'                  = 'Rider'
+        'WebStorm'               = 'WebStorm'
+        'GoLand'                 = 'GoLand'
+        'CLion'                  = 'CLion'
+        'PhpStorm'               = 'PhpStorm'
+        'RubyMine'               = 'RubyMine'
+        'DataGrip'               = 'DataGrip'
+        'RustRover'              = 'RustRover'
+    }
+    $suffix = $Id -replace '^JetBrains\.', ''
+    if ($map.ContainsKey($suffix)) { return $map[$suffix] }
+    return $Id
+}
+
+function Get-ActiveJetBrainsDisplayNames {
+    # Returns friendly display names for the ACTIVE JetBrains IDE entries in
+    # config.windows.packages, excluding JetBrains Toolbox. Commenting out an IDE
+    # in config (prefixing '# ') therefore also removes its checklist step.
+    $names = @()
+    foreach ($pkg in $config.windows.packages) {
+        if (-not (Test-ActivePackageEntry $pkg)) { continue }
+        if ($pkg -notlike 'JetBrains.*') { continue }
+        if ($pkg -like 'JetBrains.Toolbox*') { continue }
+        $names += (Get-JetBrainsDisplayName $pkg)
+    }
+    return $names
+}
+
 function Invoke-SignInStep {
     param(
         [int]$Index,
@@ -643,17 +761,22 @@ function Invoke-SignInStep {
     Write-Host ""
     Write-Host "[$Index/$Total] $Name" -ForegroundColor Cyan
 
-    $launched = $false
-    try {
-        & $Launch
-        $launched = $true
-    } catch {
-        Write-Warn "Could not launch $Name automatically: $_"
-        if ($ManualHint) { Write-Warn "Manual step: $ManualHint" }
-    }
+    if ($null -eq $Launch) {
+        # Manual-only step: nothing to launch, just surface the instructions.
+        if ($ManualHint) { Write-Info $ManualHint }
+    } else {
+        $launched = $false
+        try {
+            & $Launch
+            $launched = $true
+        } catch {
+            Write-Warn "Could not launch $Name automatically: $_"
+            if ($ManualHint) { Write-Warn "Manual step: $ManualHint" }
+        }
 
-    if ($launched -and $ManualHint) {
-        Write-Info $ManualHint
+        if ($launched -and $ManualHint) {
+            Write-Info $ManualHint
+        }
     }
 
     [void](Read-Host "  -> Press Enter once you've signed in to $Name (or to skip)")
@@ -691,68 +814,102 @@ function Start-SignInChecklist {
         Write-Info "Tip: set DEMO_GH_USER to display the expected demo account here."
     }
 
-    $total = 6
+    # Build an ordered list of step descriptors, then iterate so [index/total]
+    # is always correct as steps are added or removed.
+    $steps = @()
 
-    # ---- Step 1: Web browser (establish the browser session first) ----
-    Invoke-SignInStep -Index 1 -Total $total -Name "Web browser (github.com)" `
-        -ManualHint "Open https://github.com/login and sign in as the demo account." `
-        -Launch {
+    # ---- Web browser (establish the browser session first) ----
+    $steps += @{
+        Name       = "Web browser (github.com)"
+        ManualHint = "Open https://github.com/login and sign in as the demo account."
+        Launch     = {
             Start-Process "https://github.com/login" | Out-Null
         }
+    }
 
-    # ---- Step 2: GitHub CLI (skip if Connect-GH already authenticated) ----
+    # ---- GitHub CLI (skip if Connect-GH already authenticated) ----
     $ghAuthed = $false
     if (Get-Command gh -ErrorAction SilentlyContinue) {
         gh auth status 2>&1 | Out-Null
         if ($LASTEXITCODE -eq 0) { $ghAuthed = $true }
     }
-
-    if ($ghAuthed) {
-        Write-Host ""
-        Write-Host "[2/$total] GitHub CLI (gh)" -ForegroundColor Cyan
-        Write-Success "GitHub CLI - already authenticated, skipping"
-    } else {
-        Invoke-SignInStep -Index 2 -Total $total -Name "GitHub CLI (gh)" `
-            -ManualHint "Run 'gh auth login --web' and complete the device flow in the browser." `
-            -Launch {
-                if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { throw "gh not found on PATH" }
-                gh auth login --web
-                if ($LASTEXITCODE -ne 0) { throw "gh auth login exited with code $LASTEXITCODE" }
-            }
+    $steps += @{
+        Name        = "GitHub CLI (gh)"
+        ManualHint  = "Run 'gh auth login --web' and complete the device flow in the browser."
+        Launch      = {
+            if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { throw "gh not found on PATH" }
+            gh auth login --web
+            if ($LASTEXITCODE -ne 0) { throw "gh auth login exited with code $LASTEXITCODE" }
+        }
+        SkipIf      = $ghAuthed
+        SkipMessage = "GitHub CLI - already authenticated, skipping"
     }
 
-    # ---- Step 3: Copilot CLI (first-run device flow via /login) ----
-    Invoke-SignInStep -Index 3 -Total $total -Name "Copilot CLI (copilot)" `
-        -ManualHint "In the Copilot CLI window, run the '/login' slash command to authenticate." `
-        -Launch {
+    # ---- Copilot CLI (first-run device flow via /login) ----
+    $steps += @{
+        Name       = "Copilot CLI (copilot)"
+        ManualHint = "In the Copilot CLI window, run the '/login' slash command to authenticate."
+        Launch     = {
             $copilotCmd = Get-Command copilot -ErrorAction SilentlyContinue
             if ($null -eq $copilotCmd) { throw "copilot not found on PATH" }
             # Launch in a persistent window so the user can run /login and see any errors.
             Start-Process powershell.exe -ArgumentList @('-NoExit', '-Command', "& '$($copilotCmd.Source)'") | Out-Null
         }
+    }
 
-    # ---- Step 4: VS Code ----
-    Invoke-SignInStep -Index 4 -Total $total -Name "VS Code" `
-        -ManualHint "If Copilot doesn't prompt, sign in via the Accounts menu (bottom-left gear/avatar)." `
-        -Launch {
+    # ---- VS Code ----
+    $steps += @{
+        Name       = "VS Code"
+        ManualHint = "If Copilot doesn't prompt, sign in via the Accounts menu (bottom-left gear/avatar)."
+        Launch     = {
             if (-not (Get-Command code -ErrorAction SilentlyContinue)) { throw "code (VS Code) not found on PATH" }
             & code --command "github.copilot.signIn" 2>&1 | Out-Null
             if ($LASTEXITCODE -ne 0) { throw "code exited with code $LASTEXITCODE" }
         }
+    }
 
-    # ---- Step 5: VS Code Insiders ----
-    Invoke-SignInStep -Index 5 -Total $total -Name "VS Code Insiders" `
-        -ManualHint "If Copilot doesn't prompt, sign in via the Accounts menu (bottom-left gear/avatar)." `
-        -Launch {
+    # ---- VS Code Insiders ----
+    $steps += @{
+        Name       = "VS Code Insiders"
+        ManualHint = "If Copilot doesn't prompt, sign in via the Accounts menu (bottom-left gear/avatar)."
+        Launch     = {
             if (-not (Get-Command code-insiders -ErrorAction SilentlyContinue)) { throw "code-insiders not found on PATH" }
             & code-insiders --command "github.copilot.signIn" 2>&1 | Out-Null
             if ($LASTEXITCODE -ne 0) { throw "code-insiders exited with code $LASTEXITCODE" }
         }
+    }
 
-    # ---- Step 6: Copilot desktop app ----
-    Invoke-SignInStep -Index 6 -Total $total -Name "Copilot app (desktop)" `
-        -ManualHint "Launch the GitHub Copilot app from the Start Menu and sign in inside the app." `
-        -Launch {
+    # ---- Neovim (only when nvim is installed) ----
+    if (Get-Command nvim -ErrorAction SilentlyContinue) {
+        $steps += @{
+            Name       = "Neovim"
+            ManualHint = "Inside Neovim, run ':Copilot setup' to authenticate. If you signed in to the Copilot CLI above, Neovim may already be signed in via the shared token at %LOCALAPPDATA%\github-copilot."
+            Launch     = {
+                if (-not (Get-Command nvim -ErrorAction SilentlyContinue)) { throw "nvim not found on PATH" }
+                # Prefer Windows Terminal; fall back to a persistent PowerShell window.
+                if (Get-Command wt.exe -ErrorAction SilentlyContinue) {
+                    Start-Process wt.exe -ArgumentList 'nvim', '+":Copilot setup"' | Out-Null
+                } else {
+                    Start-Process powershell.exe -ArgumentList '-NoExit', '-Command', 'nvim +":Copilot setup"' | Out-Null
+                }
+            }
+        }
+    }
+
+    # ---- JetBrains IDEs (dynamic from active config entries; manual-hint only) ----
+    foreach ($jbName in (Get-ActiveJetBrainsDisplayNames)) {
+        $steps += @{
+            Name       = $jbName
+            ManualHint = "Open $jbName, install the GitHub Copilot plugin (Settings/Preferences > Plugins > Marketplace > search 'GitHub Copilot'), then sign in to Copilot inside the IDE."
+            Launch     = $null
+        }
+    }
+
+    # ---- Copilot desktop app (keep last) ----
+    $steps += @{
+        Name       = "Copilot app (desktop)"
+        ManualHint = "Launch the GitHub Copilot app from the Start Menu and sign in inside the app."
+        Launch     = {
             $markerDirs = Get-CopilotAppMarkerDir
 
             $exe = $null
@@ -795,6 +952,24 @@ function Start-SignInChecklist {
             if ($null -eq $exe) { throw "Copilot desktop app executable not found" }
             Start-Process $exe | Out-Null
         }
+    }
+
+    $total = $steps.Count
+    for ($i = 0; $i -lt $steps.Count; $i++) {
+        $step  = $steps[$i]
+        $index = $i + 1
+
+        if ($step.ContainsKey('SkipIf') -and $step.SkipIf) {
+            Write-Host ""
+            Write-Host "[$index/$total] $($step.Name)" -ForegroundColor Cyan
+            Write-Success $step.SkipMessage
+            continue
+        }
+
+        $launch = $null
+        if ($step.ContainsKey('Launch')) { $launch = $step.Launch }
+        Invoke-SignInStep -Index $index -Total $total -Name $step.Name -Launch $launch -ManualHint $step.ManualHint
+    }
 
     Write-Host ""
     Write-Success "Sign-in checklist complete."
@@ -1160,6 +1335,7 @@ Read-SetupInputs
 
 # Install packages
 Install-Packages
+Install-NeovimCopilot
 Install-Aspire
 Install-NpmGlobals
 Set-VLCConfiguration

--- a/setup.ps1
+++ b/setup.ps1
@@ -31,6 +31,12 @@ $script:configPath = Join-Path $PSScriptRoot "config.json"
 $script:failedItems = @()
 $script:ForceReinstall = $env:FORCE_REINSTALL -eq "true"
 
+# Per-run install choices for the optional editors. Default to $true (so unattended
+# runs install everything active, unchanged). Overridable via the INSTALL_NEOVIM /
+# INSTALL_JETBRAINS env vars or the interactive prompt. Never persisted to state.
+$script:InstallNeovim = $true
+$script:InstallJetBrains = $true
+
 function Test-ShouldSkipInstalled { return -not $script:ForceReinstall }
 
 # Returns $true if a package entry is "active" (should be installed). An entry is
@@ -206,6 +212,71 @@ function Read-SetupInputs {
     Get-SetupState
     Read-AdoOrgInput
     Read-VideoSubfolderInput
+    Read-OptionalEditorChoices
+}
+
+# Resolves a yes/no choice. Precedence: env var override (truthy 1/true/yes/y/on,
+# falsy 0/false/no/n/off) > interactive prompt (default yes) > non-interactive
+# default yes (so piped/unattended runs install everything active, unchanged).
+# Unrecognized env values or responses warn and fall back to yes.
+function Read-YesNoChoice {
+    param(
+        [string]$Question,
+        [string]$EnvVarName
+    )
+
+    if (-not [string]::IsNullOrEmpty($EnvVarName)) {
+        $raw = [Environment]::GetEnvironmentVariable($EnvVarName)
+        if ($null -ne $raw) {
+            $norm = $raw.Trim().ToLowerInvariant()
+            if ($norm -in @('1', 'true', 'yes', 'y', 'on'))  { return $true }
+            if ($norm -in @('0', 'false', 'no', 'n', 'off')) { return $false }
+            if (-not [string]::IsNullOrEmpty($norm)) {
+                Write-Warn "Unrecognized value '$raw' for $EnvVarName; ignoring it."
+            }
+        }
+    }
+
+    $interactive = $true
+    try {
+        if ([Console]::IsInputRedirected) { $interactive = $false }
+    } catch {
+        # Some hosts don't expose this; assume interactive and let Read-Host handle it.
+    }
+    if (-not $interactive) { return $true }
+
+    $answer = $null
+    try {
+        $answer = Read-Host "$Question [Y/n]"
+    } catch {
+        return $true
+    }
+
+    $trimmed = if ($null -eq $answer) { "" } else { $answer.Trim().ToLowerInvariant() }
+    if ([string]::IsNullOrEmpty($trimmed)) { return $true }
+    if ($trimmed -in @('y', 'yes')) { return $true }
+    if ($trimmed -in @('n', 'no'))  { return $false }
+    Write-Warn "Unrecognized response '$answer'; defaulting to yes."
+    return $true
+}
+
+# Asks whether to install the optional editors (Neovim, JetBrains IDEs). The
+# results gate the install loop, the Neovim Copilot plugin, and the matching
+# sign-in checklist steps. Choices are per-run only and never persisted.
+function Read-OptionalEditorChoices {
+    $script:InstallNeovim = Read-YesNoChoice -Question "Install Neovim (and auto-configure its GitHub Copilot plugin)?" -EnvVarName "INSTALL_NEOVIM"
+    if ($script:InstallNeovim) {
+        Write-Info "Neovim will be installed."
+    } else {
+        Write-Info "Skipping Neovim (and its Copilot plugin)."
+    }
+
+    $script:InstallJetBrains = Read-YesNoChoice -Question "Install JetBrains IDEs (IntelliJ IDEA, PyCharm, Rider, WebStorm)?" -EnvVarName "INSTALL_JETBRAINS"
+    if ($script:InstallJetBrains) {
+        Write-Info "JetBrains IDEs will be installed."
+    } else {
+        Write-Info "Skipping JetBrains IDEs."
+    }
 }
 
 # Prompts for the Azure DevOps organization.
@@ -435,6 +506,17 @@ function Install-Packages {
             continue
         }
 
+        # Honor the interactive install choices for the optional editors.
+        $pkgTrim = $package.Trim()
+        if ((-not $script:InstallNeovim) -and $pkgTrim -eq "Neovim.Neovim") {
+            Write-Info "Skipping Neovim (not selected): $package"
+            continue
+        }
+        if ((-not $script:InstallJetBrains) -and (Test-JetBrainsIdeEntry $package)) {
+            Write-Info "Skipping JetBrains IDE (not selected): $package"
+            continue
+        }
+
         # Chrome may be installed outside of winget (MDM, OEM, manual download, etc.)
         # so we check the filesystem to avoid install conflicts
         if ((Test-ShouldSkipInstalled) -and $package -eq "Google.Chrome" -and (Test-Path "${env:ProgramFiles}\Google\Chrome\Application\chrome.exe")) {
@@ -470,6 +552,11 @@ function Install-Packages {
 function Install-NeovimCopilot {
     # Installs the official github/copilot.vim plugin into Neovim's native package
     # start path so it loads automatically. Idempotent and never fatal.
+    if (-not $script:InstallNeovim) {
+        Write-Info "Neovim was not selected; skipping Copilot plugin setup."
+        return
+    }
+
     Write-Info "Setting up Neovim GitHub Copilot plugin..."
 
     if (-not (Get-Command nvim -ErrorAction SilentlyContinue)) {
@@ -735,6 +822,18 @@ function Get-JetBrainsDisplayName {
     return $Id
 }
 
+# Returns $true if a package entry is a JetBrains IDE (a 'JetBrains.*' id that is
+# not JetBrains Toolbox). Shared by the install-loop gate and the checklist
+# derivation so commenting out an IDE removes both its install and its step.
+function Test-JetBrainsIdeEntry {
+    param([string]$Entry)
+    if ([string]::IsNullOrWhiteSpace($Entry)) { return $false }
+    $trimmed = $Entry.Trim()
+    if ($trimmed -notlike 'JetBrains.*') { return $false }
+    if ($trimmed -like 'JetBrains.Toolbox*') { return $false }
+    return $true
+}
+
 function Get-ActiveJetBrainsDisplayNames {
     # Returns friendly display names for the ACTIVE JetBrains IDE entries in
     # config.windows.packages, excluding JetBrains Toolbox. Commenting out an IDE
@@ -742,8 +841,7 @@ function Get-ActiveJetBrainsDisplayNames {
     $names = @()
     foreach ($pkg in $config.windows.packages) {
         if (-not (Test-ActivePackageEntry $pkg)) { continue }
-        if ($pkg -notlike 'JetBrains.*') { continue }
-        if ($pkg -like 'JetBrains.Toolbox*') { continue }
+        if (-not (Test-JetBrainsIdeEntry $pkg)) { continue }
         $names += (Get-JetBrainsDisplayName $pkg)
     }
     return $names
@@ -879,8 +977,8 @@ function Start-SignInChecklist {
         }
     }
 
-    # ---- Neovim (only when nvim is installed) ----
-    if (Get-Command nvim -ErrorAction SilentlyContinue) {
+    # ---- Neovim (only when selected and nvim is installed) ----
+    if ($script:InstallNeovim -and (Get-Command nvim -ErrorAction SilentlyContinue)) {
         $steps += @{
             Name       = "Neovim"
             ManualHint = "Inside Neovim, run ':Copilot setup' to authenticate. If you signed in to the Copilot CLI above, Neovim may already be signed in via the shared token at %LOCALAPPDATA%\github-copilot."
@@ -897,11 +995,13 @@ function Start-SignInChecklist {
     }
 
     # ---- JetBrains IDEs (dynamic from active config entries; manual-hint only) ----
-    foreach ($jbName in (Get-ActiveJetBrainsDisplayNames)) {
-        $steps += @{
-            Name       = $jbName
-            ManualHint = "Open $jbName, install the GitHub Copilot plugin (Settings/Preferences > Plugins > Marketplace > search 'GitHub Copilot'), then sign in to Copilot inside the IDE."
-            Launch     = $null
+    if ($script:InstallJetBrains) {
+        foreach ($jbName in (Get-ActiveJetBrainsDisplayNames)) {
+            $steps += @{
+                Name       = $jbName
+                ManualHint = "Open $jbName, install the GitHub Copilot plugin (Settings/Preferences > Plugins > Marketplace > search 'GitHub Copilot'), then sign in to Copilot inside the IDE."
+                Launch     = $null
+            }
         }
     }
 

--- a/setup.sh
+++ b/setup.sh
@@ -31,6 +31,19 @@ should_skip_installed() {
     [[ "$FORCE_REINSTALL" != "true" ]]
 }
 
+# Returns 0 (true) if a package entry is "active" (should be installed). An entry
+# is treated as disabled (returns non-zero) when it is empty/whitespace-only or its
+# trimmed value begins with '#'. config.json can't carry real JSON comments, so we
+# document and disable packages by prefixing their name with '# '.
+is_active_package_entry() {
+    local entry="$1"
+    # Strip leading whitespace.
+    local trimmed="${entry#"${entry%%[![:space:]]*}"}"
+    [[ -n "$trimmed" ]] || return 1
+    [[ "$trimmed" != \#* ]] || return 1
+    return 0
+}
+
 # Mutable state
 failed_items=()
 
@@ -129,10 +142,10 @@ load_config() {
     while IFS= read -r line; do gh_cli_extensions+=("$line"); done < <(jq -r '.shared.gh_cli_extensions[]' "$CONFIG_FILE")
 
     brew_casks=()
-    while IFS= read -r line; do brew_casks+=("$line"); done < <(jq -r '.mac.packages.casks[]' "$CONFIG_FILE")
+    while IFS= read -r line; do brew_casks+=("$line"); done < <(jq -r '.mac.packages.casks[] | if . == null then "" else . end' "$CONFIG_FILE")
 
     brew_formulas=()
-    while IFS= read -r line; do brew_formulas+=("$line"); done < <(jq -r '.mac.packages.formulas[]' "$CONFIG_FILE")
+    while IFS= read -r line; do brew_formulas+=("$line"); done < <(jq -r '.mac.packages.formulas[] | if . == null then "" else . end' "$CONFIG_FILE")
 
     pwa_names=()
     while IFS= read -r line; do pwa_names+=("$line"); done < <(jq -r '.shared.pwa_sites[].name' "$CONFIG_FILE")
@@ -187,6 +200,12 @@ install_packages() {
     log_info "Installing Brew casks..."
 
     for cask in "${brew_casks[@]}"; do
+        # Skip disabled/documentation entries (those prefixed with '# ' in config.json).
+        if ! is_active_package_entry "$cask"; then
+            log_info "Skipping disabled package: $cask"
+            continue
+        fi
+
         # Chrome may be installed outside of brew (MDM, manual download, etc.)
         # so we check the filesystem to avoid install conflicts
         if should_skip_installed && [[ "$cask" == "google-chrome" ]] && [[ -d "/Applications/Google Chrome.app" ]]; then
@@ -199,6 +218,12 @@ install_packages() {
 
     log_info "Installing Brew formulas..."
     for formula in "${brew_formulas[@]}"; do
+        # Skip disabled/documentation entries (those prefixed with '# ' in config.json).
+        if ! is_active_package_entry "$formula"; then
+            log_info "Skipping disabled package: $formula"
+            continue
+        fi
+
         try_install "brew formula: $formula" brew install "$formula"
     done
 
@@ -226,6 +251,57 @@ install_packages() {
             log_success "nvm config added to $shell_rc"
         fi
     fi
+}
+
+# Installs the official github/copilot.vim plugin into Neovim's native package
+# start path so it loads automatically. Idempotent and never fatal.
+install_neovim_copilot() {
+    log_info "Setting up Neovim GitHub Copilot plugin..."
+
+    if ! command -v nvim &> /dev/null; then
+        log_info "Neovim (nvim) not found on PATH; skipping Copilot plugin setup."
+        return 0
+    fi
+
+    if ! command -v git &> /dev/null; then
+        log_warn "git not found on PATH; cannot install Neovim Copilot plugin. Skipping."
+        return 0
+    fi
+
+    local data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
+    local target="$data_home/nvim/site/pack/github/start/copilot.vim"
+    local parent
+    parent="$(dirname "$target")"
+
+    if [[ ! -d "$parent" ]]; then
+        if ! mkdir -p "$parent"; then
+            log_warn "Could not create Neovim plugin directory '$parent'."
+            failed_items+=("Neovim Copilot plugin (mkdir)")
+            return 0
+        fi
+    fi
+
+    if [[ ! -d "$target" ]]; then
+        if ! git clone --depth 1 https://github.com/github/copilot.vim "$target" 2>&1; then
+            log_warn "Failed to clone Neovim Copilot plugin; continuing."
+            failed_items+=("Neovim Copilot plugin (clone)")
+            return 0
+        fi
+    elif [[ -d "$target/.git" ]]; then
+        # Already a git checkout; refresh best-effort.
+        if ! git -C "$target" pull --ff-only 2>&1; then
+            log_warn "Could not update Neovim Copilot plugin (git pull failed); continuing."
+        fi
+    else
+        log_warn "Neovim Copilot plugin path exists but is not a git repo; leaving it untouched: $target"
+        return 0
+    fi
+
+    if ! command -v node &> /dev/null; then
+        log_warn "Node.js (node) not found on PATH; Neovim Copilot may not work until Node is available."
+    fi
+
+    log_success "Neovim GitHub Copilot plugin ready"
 }
 
 # Installs a suite of GitHub CLI extensions for enhanced functionality
@@ -371,7 +447,10 @@ signin_step() {
     echo ""
     echo -e "${BLUE}[$index/$total] $name${NC}"
 
-    if "$@"; then
+    if [[ $# -eq 0 ]]; then
+        # Manual-only step: nothing to launch, just surface the instructions.
+        [[ -n "$hint" ]] && log_info "$hint"
+    elif "$@"; then
         [[ -n "$hint" ]] && log_info "$hint"
     else
         log_warn "Could not launch $name automatically."
@@ -423,6 +502,52 @@ launch_copilot_app_signin() {
     fi
 }
 
+launch_neovim_signin() {
+    command -v nvim &> /dev/null || return 1
+    if [[ "$OSTYPE" == darwin* ]]; then
+        # Best-effort: open a new Terminal window running Neovim with Copilot setup.
+        osascript -e 'tell application "Terminal" to activate' \
+                  -e 'tell application "Terminal" to do script "nvim +\":Copilot setup\""' &> /dev/null
+    else
+        # TODO: verify a reliable terminal launcher across Linux desktops.
+        if command -v x-terminal-emulator &> /dev/null; then
+            x-terminal-emulator -e nvim +":Copilot setup" &> /dev/null &
+        else
+            return 1
+        fi
+    fi
+}
+
+# Returns 0 if the given Homebrew cask is a known JetBrains IDE.
+is_jetbrains_cask() {
+    case "$1" in
+        intellij-idea|intellij-idea-ce|pycharm|pycharm-ce|rider|webstorm|goland|clion|phpstorm|rubymine|datagrip|rustrover)
+            return 0 ;;
+        *)
+            return 1 ;;
+    esac
+}
+
+# Maps a JetBrains Homebrew cask to a friendly display name. Unknown casks fall
+# back to the raw cask name so we never crash.
+jetbrains_cask_display_name() {
+    case "$1" in
+        intellij-idea)     echo "IntelliJ IDEA Ultimate" ;;
+        intellij-idea-ce)  echo "IntelliJ IDEA Community" ;;
+        pycharm)           echo "PyCharm Professional" ;;
+        pycharm-ce)        echo "PyCharm Community" ;;
+        rider)             echo "Rider" ;;
+        webstorm)          echo "WebStorm" ;;
+        goland)            echo "GoLand" ;;
+        clion)             echo "CLion" ;;
+        phpstorm)          echo "PhpStorm" ;;
+        rubymine)          echo "RubyMine" ;;
+        datagrip)          echo "DataGrip" ;;
+        rustrover)         echo "RustRover" ;;
+        *)                 echo "$1" ;;
+    esac
+}
+
 # Guides the user through signing in to every GitHub surface, one at a time.
 # Order matters: the browser session is established first so the other tools
 # inherit the correct account.
@@ -451,43 +576,99 @@ start_signin_checklist() {
         log_info "Tip: set DEMO_GH_USER to display the expected demo account here."
     fi
 
-    local total=6
+    # Build ordered, parallel arrays of step descriptors so [index/total] is always
+    # correct as steps are added or removed. Each launcher is a command string
+    # ("" for a manual-hint-only step); step_skip marks a step as already done.
+    local step_names=()
+    local step_hints=()
+    local step_launchers=()
+    local step_skip=()
 
-    # Step 1: Web browser (establish the browser session first)
-    signin_step 1 "$total" "Web browser (github.com)" \
+    add_signin_step() {
+        step_names+=("$1")
+        step_hints+=("$2")
+        step_launchers+=("$3")
+        step_skip+=("${4:-false}")
+    }
+
+    # Web browser (establish the browser session first)
+    add_signin_step "Web browser (github.com)" \
         "Open https://github.com/login and sign in as the demo account." \
-        launch_browser_signin
+        "launch_browser_signin"
 
-    # Step 2: GitHub CLI (skip if authenticate_gh already signed in)
+    # GitHub CLI (skip if authenticate_gh already signed in)
+    local gh_skip="false"
     if command -v gh &> /dev/null && gh auth status &> /dev/null; then
-        echo ""
-        echo -e "${BLUE}[2/$total] GitHub CLI (gh)${NC}"
-        log_success "GitHub CLI - already authenticated, skipping"
-    else
-        signin_step 2 "$total" "GitHub CLI (gh)" \
-            "Run 'gh auth login --web' and complete the device flow in the browser." \
-            gh auth login --web
+        gh_skip="true"
+    fi
+    add_signin_step "GitHub CLI (gh)" \
+        "Run 'gh auth login --web' and complete the device flow in the browser." \
+        "gh auth login --web" \
+        "$gh_skip"
+
+    # Copilot CLI (first-run device flow via /login)
+    add_signin_step "Copilot CLI (copilot)" \
+        "In the Copilot CLI window, run the '/login' slash command to authenticate." \
+        "launch_copilot_cli_signin"
+
+    # VS Code
+    add_signin_step "VS Code" \
+        "If Copilot doesn't prompt, sign in via the Accounts menu (bottom-left)." \
+        "launch_editor_signin code"
+
+    # VS Code Insiders
+    add_signin_step "VS Code Insiders" \
+        "If Copilot doesn't prompt, sign in via the Accounts menu (bottom-left)." \
+        "launch_editor_signin code-insiders"
+
+    # Neovim (only when nvim is installed)
+    if command -v nvim &> /dev/null; then
+        add_signin_step "Neovim" \
+            "Inside Neovim, run ':Copilot setup' to authenticate. If you signed in to the Copilot CLI above, Neovim may already be signed in via the shared token at ~/.config/github-copilot." \
+            "launch_neovim_signin"
     fi
 
-    # Step 3: Copilot CLI (first-run device flow via /login)
-    signin_step 3 "$total" "Copilot CLI (copilot)" \
-        "In the Copilot CLI window, run the '/login' slash command to authenticate." \
-        launch_copilot_cli_signin
+    # JetBrains IDEs (dynamic from active config casks; manual-hint only). Commenting
+    # out an IDE in config also removes its checklist step automatically.
+    local cask jb_name
+    for cask in "${brew_casks[@]}"; do
+        is_active_package_entry "$cask" || continue
+        is_jetbrains_cask "$cask" || continue
+        jb_name="$(jetbrains_cask_display_name "$cask")"
+        add_signin_step "$jb_name" \
+            "Open $jb_name, install the GitHub Copilot plugin (Settings/Preferences > Plugins > Marketplace > search 'GitHub Copilot'), then sign in to Copilot inside the IDE." \
+            ""
+    done
 
-    # Step 4: VS Code
-    signin_step 4 "$total" "VS Code" \
-        "If Copilot doesn't prompt, sign in via the Accounts menu (bottom-left)." \
-        launch_editor_signin code
-
-    # Step 5: VS Code Insiders
-    signin_step 5 "$total" "VS Code Insiders" \
-        "If Copilot doesn't prompt, sign in via the Accounts menu (bottom-left)." \
-        launch_editor_signin code-insiders
-
-    # Step 6: Copilot desktop app
-    signin_step 6 "$total" "Copilot app (desktop)" \
+    # Copilot desktop app (keep last)
+    add_signin_step "Copilot app (desktop)" \
         "Launch the GitHub Copilot app and sign in inside the app." \
-        launch_copilot_app_signin
+        "launch_copilot_app_signin"
+
+    local total=${#step_names[@]}
+    local i index name hint launcher skip
+    for (( i=0; i<total; i++ )); do
+        index=$(( i + 1 ))
+        name="${step_names[$i]}"
+        hint="${step_hints[$i]}"
+        launcher="${step_launchers[$i]}"
+        skip="${step_skip[$i]}"
+
+        if [[ "$skip" == "true" ]]; then
+            echo ""
+            echo -e "${BLUE}[$index/$total] $name${NC}"
+            log_success "$name - already authenticated, skipping"
+            continue
+        fi
+
+        if [[ -z "$launcher" ]]; then
+            signin_step "$index" "$total" "$name" "$hint"
+        else
+            local launcher_parts=()
+            read -ra launcher_parts <<< "$launcher"
+            signin_step "$index" "$total" "$name" "$hint" "${launcher_parts[@]}"
+        fi
+    done
 
     echo ""
     log_success "Sign-in checklist complete."
@@ -1040,6 +1221,7 @@ prompt_for_inputs
 
 # Install packages
 install_packages
+install_neovim_copilot
 install_aspire
 install_npm_globals
 configure_vlc

--- a/setup.sh
+++ b/setup.sh
@@ -44,8 +44,23 @@ is_active_package_entry() {
     return 0
 }
 
+# Trims leading and trailing whitespace from $1 and prints the result.
+trim_ws() {
+    local s="$1"
+    s="${s#"${s%%[![:space:]]*}"}"
+    s="${s%"${s##*[![:space:]]}"}"
+    printf '%s' "$s"
+}
+
 # Mutable state
 failed_items=()
+
+# Per-run install choices for the optional editors (Neovim, JetBrains IDEs).
+# Default to true (so unattended runs install everything active, unchanged).
+# Overridable via INSTALL_NEOVIM / INSTALL_JETBRAINS env vars or the interactive
+# prompt. Per-run only; never persisted to setup state.
+WANT_NEOVIM=true
+WANT_JETBRAINS=true
 
 # When true, the interactive sign-in checklist is skipped
 SKIP_SIGNIN="${SKIP_SIGNIN:-false}"
@@ -206,6 +221,12 @@ install_packages() {
             continue
         fi
 
+        # Honor the interactive JetBrains install choice.
+        if [[ "$WANT_JETBRAINS" != "true" ]] && is_jetbrains_cask "$(trim_ws "$cask")"; then
+            log_info "Skipping JetBrains IDE (not selected): $cask"
+            continue
+        fi
+
         # Chrome may be installed outside of brew (MDM, manual download, etc.)
         # so we check the filesystem to avoid install conflicts
         if should_skip_installed && [[ "$cask" == "google-chrome" ]] && [[ -d "/Applications/Google Chrome.app" ]]; then
@@ -221,6 +242,12 @@ install_packages() {
         # Skip disabled/documentation entries (those prefixed with '# ' in config.json).
         if ! is_active_package_entry "$formula"; then
             log_info "Skipping disabled package: $formula"
+            continue
+        fi
+
+        # Honor the interactive Neovim install choice.
+        if [[ "$WANT_NEOVIM" != "true" ]] && [[ "$(trim_ws "$formula")" == "neovim" ]]; then
+            log_info "Skipping Neovim (not selected): $formula"
             continue
         fi
 
@@ -256,6 +283,11 @@ install_packages() {
 # Installs the official github/copilot.vim plugin into Neovim's native package
 # start path so it loads automatically. Idempotent and never fatal.
 install_neovim_copilot() {
+    if [[ "$WANT_NEOVIM" != "true" ]]; then
+        log_info "Neovim was not selected; skipping Copilot plugin setup."
+        return 0
+    fi
+
     log_info "Setting up Neovim GitHub Copilot plugin..."
 
     if ! command -v nvim &> /dev/null; then
@@ -621,8 +653,8 @@ start_signin_checklist() {
         "If Copilot doesn't prompt, sign in via the Accounts menu (bottom-left)." \
         "launch_editor_signin code-insiders"
 
-    # Neovim (only when nvim is installed)
-    if command -v nvim &> /dev/null; then
+    # Neovim (only when selected and nvim is installed)
+    if [[ "$WANT_NEOVIM" == "true" ]] && command -v nvim &> /dev/null; then
         add_signin_step "Neovim" \
             "Inside Neovim, run ':Copilot setup' to authenticate. If you signed in to the Copilot CLI above, Neovim may already be signed in via the shared token at ~/.config/github-copilot." \
             "launch_neovim_signin"
@@ -630,15 +662,18 @@ start_signin_checklist() {
 
     # JetBrains IDEs (dynamic from active config casks; manual-hint only). Commenting
     # out an IDE in config also removes its checklist step automatically.
-    local cask jb_name
-    for cask in "${brew_casks[@]}"; do
-        is_active_package_entry "$cask" || continue
-        is_jetbrains_cask "$cask" || continue
-        jb_name="$(jetbrains_cask_display_name "$cask")"
-        add_signin_step "$jb_name" \
-            "Open $jb_name, install the GitHub Copilot plugin (Settings/Preferences > Plugins > Marketplace > search 'GitHub Copilot'), then sign in to Copilot inside the IDE." \
-            ""
-    done
+    if [[ "$WANT_JETBRAINS" == "true" ]]; then
+        local cask jb_name
+        for cask in "${brew_casks[@]}"; do
+            is_active_package_entry "$cask" || continue
+            cask="$(trim_ws "$cask")"
+            is_jetbrains_cask "$cask" || continue
+            jb_name="$(jetbrains_cask_display_name "$cask")"
+            add_signin_step "$jb_name" \
+                "Open $jb_name, install the GitHub Copilot plugin (Settings/Preferences > Plugins > Marketplace > search 'GitHub Copilot'), then sign in to Copilot inside the IDE." \
+                ""
+        done
+    fi
 
     # Copilot desktop app (keep last)
     add_signin_step "Copilot app (desktop)" \
@@ -804,6 +839,73 @@ prompt_for_inputs() {
     load_setup_state
     prompt_for_ado_org
     prompt_for_video_subfolder
+    prompt_for_optional_editors
+}
+
+# Resolves an install choice into the global named by $1 ("true"/"false").
+# Precedence: env var override > interactive prompt (default yes) > non-interactive
+# default yes (so piped/unattended runs install everything active, unchanged).
+# Per-run only; never persisted. Args:
+#   $1 = output global var name, $2 = question, $3 = env var name (for messages),
+#   $4 = env state ("set"/"unset"), $5 = raw env value.
+resolve_optional_editor_choice() {
+    local out_var="$1" question="$2" env_name="$3" env_state="$4" raw="$5"
+    local norm answer
+
+    if [[ "$env_state" == "set" ]]; then
+        norm="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+        norm="$(trim_ws "$norm")"
+        case "$norm" in
+            1|true|yes|y|on)  printf -v "$out_var" '%s' "true";  return 0 ;;
+            0|false|no|n|off) printf -v "$out_var" '%s' "false"; return 0 ;;
+            "") : ;;
+            *) log_warn "Unrecognized value '$raw' for $env_name; ignoring it." ;;
+        esac
+    fi
+
+    # Only prompt when both stdin and stdout are TTYs (matches prompt_for_inputs).
+    if [[ ! -t 0 ]] || [[ ! -t 1 ]]; then
+        printf -v "$out_var" '%s' "true"
+        return 0
+    fi
+
+    printf '%s [Y/n]\n> ' "$question" >&2
+    IFS= read -r answer || answer=""
+    norm="$(printf '%s' "$answer" | tr '[:upper:]' '[:lower:]')"
+    norm="$(trim_ws "$norm")"
+    case "$norm" in
+        ""|y|yes) printf -v "$out_var" '%s' "true" ;;
+        n|no)     printf -v "$out_var" '%s' "false" ;;
+        *) log_warn "Unrecognized response '$answer'; defaulting to yes."
+           printf -v "$out_var" '%s' "true" ;;
+    esac
+}
+
+# Asks whether to install the optional editors (Neovim, JetBrains IDEs). The
+# results gate the install loop, the Neovim Copilot plugin, and the matching
+# sign-in checklist steps. Choices are per-run only and never persisted.
+prompt_for_optional_editors() {
+    local nv_state="unset" nv_raw=""
+    if [[ -n "${INSTALL_NEOVIM+x}" ]]; then nv_state="set"; nv_raw="$INSTALL_NEOVIM"; fi
+    resolve_optional_editor_choice WANT_NEOVIM \
+        "Install Neovim (and auto-configure its GitHub Copilot plugin)?" \
+        "INSTALL_NEOVIM" "$nv_state" "$nv_raw"
+    if [[ "$WANT_NEOVIM" == "true" ]]; then
+        log_info "Neovim will be installed."
+    else
+        log_info "Skipping Neovim (and its Copilot plugin)."
+    fi
+
+    local jb_state="unset" jb_raw=""
+    if [[ -n "${INSTALL_JETBRAINS+x}" ]]; then jb_state="set"; jb_raw="$INSTALL_JETBRAINS"; fi
+    resolve_optional_editor_choice WANT_JETBRAINS \
+        "Install JetBrains IDEs (IntelliJ IDEA, PyCharm, Rider, WebStorm)?" \
+        "INSTALL_JETBRAINS" "$jb_state" "$jb_raw"
+    if [[ "$WANT_JETBRAINS" == "true" ]]; then
+        log_info "JetBrains IDEs will be installed."
+    else
+        log_info "Skipping JetBrains IDEs."
+    fi
 }
 
 # Prompts (when TTY) for the Azure DevOps org. Sets ADO_ORG_VALUE


### PR DESCRIPTION
## Summary

Adds Neovim and a configurable set of IDEs to both installers (`setup.ps1` for Windows, `setup.sh` for macOS/Linux), with an easy "comment out" mechanism, **interactive yes/no prompts** to opt in/out, auto-install of Neovim's GitHub Copilot plugin, and an extended interactive sign-in checklist.

## Active IDE set (final)

Default-active IDEs are **PyCharm Professional**, **Rider**, and **Android Studio** on both OSes, plus **Neovim**. Every other IDE ships present-but-commented-out (the `# ` convention) and is one edit away:

- **Windows** (`windows.packages`): active `Neovim.Neovim`, `JetBrains.PyCharm.Professional`, `JetBrains.Rider`, `Google.AndroidStudio`. Commented-out: `JetBrains.IntelliJIDEA.Ultimate`, `JetBrains.WebStorm`, GoLand, CLion, PhpStorm, RubyMine, DataGrip, RustRover. Includes a self-documenting skip-note as the first entry.
- **macOS** (`mac.packages`): active casks `pycharm`, `rider`, `android-studio`; commented-out `intellij-idea`, `webstorm`, goland, clion, phpstorm, rubymine, datagrip, rustrover. Adds `neovim` and `node` formulas (Node is required by the Copilot plugin).

> PyCharm is the paid **Professional** edition; flipping to Community is a one-line change (`JetBrains.PyCharm.Community` / `pycharm-ce`).

## Interactive install prompts

Both scripts ask two yes/no questions early in the run:

- `Install Neovim (and auto-configure its GitHub Copilot plugin)?`
- `Install JetBrains IDEs (PyCharm, Rider) and Android Studio?`

Declining skips the relevant packages, the Neovim Copilot plugin setup, and the matching sign-in checklist steps. Pressing Enter accepts the default (yes).

- **Precedence:** `INSTALL_NEOVIM` / `INSTALL_JETBRAINS` env vars (truthy `1/true/yes/y/on`, falsy `0/false/no/n/off`) > interactive prompt > non-interactive default **yes**, so piped/unattended runs install everything active exactly as before. `INSTALL_JETBRAINS` gates the whole IDE bucket, including Android Studio.
- Choices are **per-run only** and never persisted.

## IDE bucket: JetBrains + Android Studio

Android Studio is a Google package, not `JetBrains.*`, so the IDE predicate is broadened to cover it. A single shared predicate (`Test-IdeEntry` / `is_ide_cask`) is reused by both the install-loop gate and the checklist derivation, so commenting an IDE out removes both its install and its sign-in step, and behavior never drifts. Display names come from an explicit mapping table (Android Studio -> "Android Studio"), and `Google.Chrome` is correctly **not** treated as an IDE.

## `#` comment-out convention

Because JSON can't carry real comments, any package entry whose trimmed value starts with `#` is treated as disabled. A shared helper (`Test-ActivePackageEntry` / `is_active_package_entry`) enforces this at the top of every install loop (Windows packages, mac casks, mac formulas) and in the checklist's IDE derivation. `winget install "# JetBrains.WebStorm"` / `brew install "# webstorm"` can never run. Per-item failure isolation is preserved.

## Neovim Copilot plugin auto-install

`Install-NeovimCopilot` / `install_neovim_copilot` clones `github/copilot.vim` into Neovim's native package start path. Idempotent and never fatal: skips when not selected or when `nvim`/`git` are missing, creates the parent dir, clones if absent or `git pull --ff-only` if already a repo, leaves non-repo dirs untouched, and warns (but continues) if Node isn't on PATH. Authentication is left to the checklist.

## Array-driven sign-in checklist

The checklist builds an ordered step list and computes `[index/total]` from its length. Sequence: browser -> gh -> Copilot CLI -> VS Code -> VS Code Insiders -> **Neovim** (only if selected and `nvim` on PATH) -> **one step per active IDE** (PyCharm, Rider, Android Studio by default) -> Copilot app (last). IDE steps are manual-hint-only (install the GitHub Copilot plugin via Settings/Preferences > Plugins > Marketplace, then sign in inside the IDE; Android Studio uses the same JetBrains marketplace). Existing behavior preserved: `-SkipSignIn` / `--skip-signin`, the non-interactive guard, the `DEMO_GH_USER` banner, the gh "already authenticated -> skip" case, and existing launchers.

## Validation

- `jq empty config.json` clean; active-set derivation verified against the real config (only PyCharm + Rider + Android Studio resolve active on both OSes); shared VLC/demo-loader config untouched.
- PowerShell AST `ParseFile` yields zero errors; syntax kept 5.1-safe; no new non-ASCII characters. Predicate/display logic unit-tested in `pwsh`.
- `bash -n setup.sh` clean under default bash and macOS bash 3.2; shellcheck introduces no new warnings; `is_ide_cask` / display-name logic verified under bash 3.2.
- Default behavior (no config edits, prompts accepted or non-interactive): PyCharm + Rider + Android Studio + Neovim install; everything else skipped.