### PR TITLE
Use native Media Player on Windows and enforce PS7 + admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Booth Machine Setup
 
-This repository contains setup scripts for configuring booth machines. The scripts install and configure Visual Studio Code, Visual Studio Code Insiders, GitHub CLI, VLC media player, and other necessary tools.
+This repository contains setup scripts for configuring booth machines. The scripts install and configure Visual Studio Code, Visual Studio Code Insiders, GitHub CLI, a media player, and other necessary tools.
 
 ## Features
 
@@ -13,7 +13,7 @@ This repository contains setup scripts for configuring booth machines. The scrip
 - Installs the [Microsoft Aspire](https://aspire.dev) CLI and registers its MCP server with Copilot CLI.
 - Installs Visual Studio Enterprise with Web + Azure + .NET desktop workloads (Windows only).
 - Registers MCP servers (Playwright, Microsoft Learn, Astro docs, Svelte docs, Aspire, Azure, Azure DevOps) in `~/.copilot/mcp-config.json`. Node-based MCP servers (Playwright, Azure, Azure DevOps) are installed globally via `npm install -g` so they launch from their installed binaries rather than fetching via `npx` at runtime.
-- Configures VLC media player settings.
+- Configures VLC media player settings (macOS only; Windows uses the built-in Media Player).
 - Sets up Progressive Web Apps (PWAs) for GitHub tools.
 - Creates a demo loader script to launch all required applications and sites.
 
@@ -64,15 +64,21 @@ The interactive sign-in checklist walks you through signing in to each GitHub su
 
 ### Windows
 
-1. Open PowerShell as an administrator.
-2. Navigate to the repository directory.
-3. Run the setup script to configure the machine:
+1. Install PowerShell 7 if it isn't already present (`winget install Microsoft.PowerShell`).
+2. Open **PowerShell 7** as an administrator (right-click > Run as Administrator). Running as a standard user triggers UAC approval prompts that break the unattended flow.
+3. Allow the script to run in this session:
+
+    ```powershell
+    Set-ExecutionPolicy -Scope Process -ExecutionPolicy Unrestricted
+    ```
+4. Navigate to the repository directory.
+5. Run the setup script to configure the machine:
 
     ```powershell
     .\setup.ps1
     ```
-4. A script will be created on the Desktop to load up the necessary applications.
-5. Store any booth videos in the `C:\Users\<YourUsername>\Videos` folder for easier loading from VLC.
+6. A script will be created on the Desktop to load up the necessary applications.
+7. Store any booth videos in the `C:\Users\<YourUsername>\Videos` folder; the demo loader opens this folder so you can play them in the built-in Media Player.
 
 ## License
 
@@ -103,7 +109,7 @@ Azure DevOps organization name (leave blank to skip the Azure DevOps MCP server)
 
 ### Demo video subfolder
 
-The demo loader opens VLC pointed at your `~/Videos` folder. If you copy the same full set of videos to every machine but organize them into subfolders (e.g. `~/Videos/booth-keynote`, `~/Videos/booth-security`), setup can point this machine's loader at just one of them. Setup prompts you for the subfolder once and caches the answer.
+The demo loader opens your `~/Videos` folder (in VLC on macOS, or in Explorer on Windows so you can play videos in the built-in Media Player). If you copy the same full set of videos to every machine but organize them into subfolders (e.g. `~/Videos/booth-keynote`, `~/Videos/booth-security`), setup can point this machine's loader at just one of them. Setup prompts you for the subfolder once and caches the answer.
 
 **During setup:**
 

--- a/config.json
+++ b/config.json
@@ -144,7 +144,6 @@
       "Microsoft.VisualStudioCode.Insiders",
       "Microsoft.WindowsTerminal",
       "GitHub.cli",
-      "VideoLAN.VLC",
       "GitHub.Copilot",
       "Google.Chrome",
       "GitHub.GitHubDesktop",

--- a/setup.ps1
+++ b/setup.ps1
@@ -14,6 +14,7 @@
 .NOTES
     Requires:
     - Windows 10/11
+    - PowerShell 7 or later (run from 'pwsh', not Windows PowerShell 5.1)
     - winget package manager
     - Administrative privileges
     - Internet connection
@@ -94,13 +95,23 @@ function Write-Summary {
 # ----------------------------------------
 
 function Test-Prerequisites {
-    # Check for admin privileges
+    # Require PowerShell 7+. Windows PowerShell 5.1 (the in-box default) trips over
+    # several install steps, so fail fast with guidance instead of failing midway.
+    if ($PSVersionTable.PSVersion.Major -lt 7) {
+        Write-Err "PowerShell 7 or later is required (detected $($PSVersionTable.PSVersion))."
+        Write-Err "Install it with 'winget install Microsoft.PowerShell', then re-run this script from 'pwsh'."
+        return $false
+    }
+    Write-Success "Running on PowerShell $($PSVersionTable.PSVersion)"
+
+    # Require Administrator. Running as a standard user forces UAC approval prompts
+    # that break the unattended flow, so make it a hard requirement.
     $isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
     if ($isAdmin) {
         Write-Success "Running with Administrator privileges"
     } else {
-        Write-Warn "Not running with Administrator privileges. Some operations may fail."
-        Write-Warn "Consider restarting with 'Run as Administrator'"
+        Write-Err "Administrator privileges are required. Right-click PowerShell 7 and choose 'Run as Administrator', then re-run this script."
+        return $false
     }
 
     # Verify config.json exists
@@ -714,26 +725,6 @@ function Install-GHExtensions {
             gh extension install $ext 2>&1
         }
     }
-}
-
-function Set-VLCConfiguration {
-    Write-Info "Configuring VLC settings..."
-    $vlcConfigPath = "$env:APPDATA\vlc\vlcrc"
-
-    if ((Test-ShouldSkipInstalled) -and (Test-Path $vlcConfigPath)) {
-        if (Select-String -Path $vlcConfigPath -Pattern "Setup-script-configured=true" -Quiet) {
-            Write-Info "VLC settings already configured, skipping..."
-            return
-        }
-    } else {
-        New-Item -Path (Split-Path $vlcConfigPath) -ItemType Directory -Force | Out-Null
-        New-Item -Path $vlcConfigPath -ItemType File -Force | Out-Null
-    }
-
-    Add-Content -Path $vlcConfigPath -Value "# Setup-script-configured=true"
-    Add-Content -Path $vlcConfigPath -Value $config.shared.vlc_settings
-
-    Write-Success "VLC settings configured - please restart VLC"
 }
 
 function Set-EditorTheme {
@@ -1408,12 +1399,12 @@ function New-DemoLoader {
     }
     $lines += ""
 
-    # Add VLC
-    $lines += "# Open VLC"
+    # Add Videos folder
+    $lines += "# Open the Videos folder in Explorer (double-click a video to play in the native Media Player)"
     if (-not [string]::IsNullOrEmpty($script:VideoSubfolder)) {
-        $lines += 'Start-Process "vlc" -ArgumentList "$env:USERPROFILE\Videos\' + $script:VideoSubfolder + '"'
+        $lines += 'Start-Process explorer.exe -ArgumentList "$env:USERPROFILE\Videos\' + $script:VideoSubfolder + '"'
     } else {
-        $lines += 'Start-Process "vlc" -ArgumentList "$env:USERPROFILE\Videos"'
+        $lines += 'Start-Process explorer.exe -ArgumentList "$env:USERPROFILE\Videos"'
     }
     $lines += ""
     $lines += "Write-Host 'Demo environment loaded!' -ForegroundColor Green"
@@ -1446,7 +1437,6 @@ Install-Packages
 Install-NeovimCopilot
 Install-Aspire
 Install-NpmGlobals
-Set-VLCConfiguration
 
 # Launch post-install apps
 Start-PostInstallApps


### PR DESCRIPTION
## What & why

Incorporates learnings from MSFT Build for the Windows setup flow.

### 1. Drop VLC on Windows → use the built-in Media Player
- Removed `VideoLAN.VLC` from `windows.packages` in `config.json`.
- Removed `Set-VLCConfiguration` (and its call) from `setup.ps1`.
- The demo loader now opens the `~/Videos` folder (honoring the cached subfolder) in Explorer, so videos play in the native Media Player.
- macOS is unchanged — it still installs and configures VLC.

### 2. Enforce PowerShell 7 + Administrator
A standard-user run triggered UAC approval prompts that broke the unattended flow. `Test-Prerequisites` now **fails fast with a clear message** when:
- not running on PowerShell 7+, or
- not running as Administrator.

### 3. README
- Windows instructions now cover installing PowerShell 7, running pwsh as admin, and `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Unrestricted`.
- Clarified that VLC config is macOS-only and Windows uses the built-in Media Player.

## Validation
- `config.json` parses as valid JSON.
- `setup.ps1` parses cleanly via the PowerShell language parser.